### PR TITLE
Enable Feedback and Clean up UI

### DIFF
--- a/webapp/src/components/chat/chat-history/UserFeedbackActions.tsx
+++ b/webapp/src/components/chat/chat-history/UserFeedbackActions.tsx
@@ -16,9 +16,10 @@ const useClasses = makeStyles({
 
 interface IUserFeedbackProps {
     messageIndex: number;
+    wasHelpful?: number;
 }
 
-export const UserFeedbackActions: React.FC<IUserFeedbackProps> = ({ messageIndex }) => {
+export const UserFeedbackActions: React.FC<IUserFeedbackProps> = ({ messageIndex, wasHelpful }) => {
     const classes = useClasses();
 
     const dispatch = useAppDispatch();
@@ -42,11 +43,11 @@ export const UserFeedbackActions: React.FC<IUserFeedbackProps> = ({ messageIndex
     return (
         <div className={classes.root}>
             <Text color="gray" size={200}>
-                AI-generated content may be incorrect
+                Was this response helpful?
             </Text>
-            <Tooltip content={'Like bot message'} relationship="label">
+            <Tooltip content={'Like'} relationship="label">
                 <Button
-                    icon={<ThumbLike16 />}
+                    icon={<ThumbLike16 filled={wasHelpful === UserFeedback.Positive} />}
                     appearance="transparent"
                     aria-label="Edit"
                     onClick={() => {
@@ -54,9 +55,9 @@ export const UserFeedbackActions: React.FC<IUserFeedbackProps> = ({ messageIndex
                     }}
                 />
             </Tooltip>
-            <Tooltip content={'Dislike bot message'} relationship="label">
+            <Tooltip content={'Dislike'} relationship="label">
                 <Button
-                    icon={<ThumbDislike16 />}
+                    icon={<ThumbDislike16 filled={wasHelpful === UserFeedback.Negative} />}
                     appearance="transparent"
                     aria-label="Edit"
                     onClick={() => {

--- a/webapp/src/redux/features/app/AppState.ts
+++ b/webapp/src/redux/features/app/AppState.ts
@@ -108,7 +108,7 @@ export const Features = {
         description: 'Enable multi-user chat sessions. Not available when authorization is disabled.',
     },
     [FeatureKeys.RLHF]: {
-        enabled: false,
+        enabled: true,
         label: 'Reinforcement Learning from Human Feedback',
         description: 'Enable users to vote on model-generated responses. For demonstration purposes only.',
         // TODO: [Issue #42] Send and store feedback in backend


### PR DESCRIPTION
* Set feedback flag to enabled by default
* Update UI to show/hide thumbs up/down on hover
* Show button as filled grey when it is selected, as opposed to outside the box like the default
* Not currently persisted but does update the message properties, so ideally when message persistence is implemented this comes for free