### PR TITLE
Create First Chat + Centered Specialization Carousel

### DIFF
--- a/webapp/src/components/specialization/SpecializationCardList.tsx
+++ b/webapp/src/components/specialization/SpecializationCardList.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@fluentui/react-components';
-import React, { useId } from 'react';
+import React, { useMemo } from 'react';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import { ISpecialization } from '../../libs/models/Specialization';
@@ -27,53 +27,62 @@ const responsive = {
 };
 
 const useClasses = makeStyles({
+    carouselroot: {
+        width: '700px',
+    },
+    // Allows for the carousel to be centered when there is only one item
+    carouselrootSingleItem: {
+        width: '700px',
+        display: 'flex',
+        justifyContent: 'center',
+    },
     innercontainerclass: {
         height: '330px',
-        position: 'relative',
-        display: 'block',
     },
     innertitle: {
         textAlign: 'center',
     },
-    carouselroot: {
-        position: 'relative',
-        //marginRight: 'calc(100% - 1024px)',
-        display: 'block',
-        width: '700px',
-    },
 });
 
 interface SpecializationProps {
-    /* eslint-disable 
-      @typescript-eslint/no-unsafe-assignment
-    */
     specializations: ISpecialization[];
 }
 
+/**
+ * Renders the SpecializationCardList Carousel component.
+ *
+ * Note: Dynamic styling to handle the case when there is only one specialization.
+ *
+ * @param {{specializations: ISpecialization[]}} - List of specializations
+ * @returns {*} Specialization Carousel select component
+ */
 export const SpecializationCardList: React.FC<SpecializationProps> = ({ specializations }) => {
-    const specializaionCarouselId = useId();
-    const specializaionCardId = useId();
     const classes = useClasses();
-    const { app } = useAppSelector((state: RootState) => state);
-    const filteredSpecializations = specializations.filter((_specialization) => {
-        const hasMembership =
-            app.activeUserInfo?.groups.some((val) => {
-                return _specialization.groupMemberships.includes(val);
-            }) ?? false;
-        if (
-            ((hasMembership || _specialization.groupMemberships.length === 0) && _specialization.isActive) ||
-            _specialization.id == 'general'
-        ) {
-            return _specialization;
-        }
-        return;
-    });
+    const { activeUserInfo } = useAppSelector((state: RootState) => state.app);
+
+    // Memoize the filtered specializations based on the user's group memberships
+    const filteredSpecializations = useMemo(() => {
+        return specializations.filter((_specialization) => {
+            const hasMembership =
+                activeUserInfo?.groups.some((val) => {
+                    return _specialization.groupMemberships.includes(val);
+                }) ?? false;
+
+            // Check if the user has membership to the specialization group and the specialization is active
+            const canViewSpecialization =
+                ((hasMembership || _specialization.groupMemberships.length === 0) && _specialization.isActive) ||
+                _specialization.id == 'general';
+
+            return canViewSpecialization ? _specialization : undefined;
+        });
+    }, [activeUserInfo?.groups, specializations]);
+
     return (
-        <div className={classes.carouselroot}>
+        <>
             <h1 className={classes.innertitle}>Choose Specialization</h1>
             <Carousel
+                className={filteredSpecializations.length === 1 ? classes.carouselrootSingleItem : classes.carouselroot}
                 responsive={responsive}
-                key={specializaionCarouselId}
                 showDots={true}
                 swipeable={true}
                 arrows={true}
@@ -81,13 +90,10 @@ export const SpecializationCardList: React.FC<SpecializationProps> = ({ speciali
             >
                 {filteredSpecializations.map((_specialization, index) => (
                     <div key={index} className={classes.innercontainerclass}>
-                        <SpecializationCard
-                            key={specializaionCardId + '_' + index.toString()}
-                            specialization={_specialization}
-                        />
+                        <SpecializationCard key={_specialization.id} specialization={_specialization} />
                     </div>
                 ))}
             </Carousel>
-        </div>
+        </>
     );
 };

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -231,7 +231,7 @@ export const useChat = () => {
                 }
             } else {
                 // No chats exist, create first chat window
-                //await createChat();
+                await createChat();
             }
 
             return true;


### PR DESCRIPTION
### Motivation and Context
- A chat should be automatically created when first loading app
- Specialization carousel should be centered when only one Specialization (ie: General)

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
- Automatically creates first chat if no current chats exist for user
- Fixed styling issue with specializations carousel not centering content (note: only centers when there is one item, and renders the same when more)

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
