### PR TITLE
Automatically use default specialization when messaging without selecting one

### DIFF
--- a/webapp/src/components/chat/chat-list/bot-menu/SimplifiedNewBotMenu.tsx
+++ b/webapp/src/components/chat/chat-list/bot-menu/SimplifiedNewBotMenu.tsx
@@ -34,7 +34,7 @@ export const SimplifiedNewBotMenu: FC<SimplifiedNewBotMenuProps> = () => {
     const [isJoiningBot, setIsJoiningBot] = useState(false);
 
     const onAddChat = () => {
-        void chat.createChat();
+        void chat.createChat('');
     };
     const onJoinClick = () => {
         setIsJoiningBot(true);

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -47,7 +47,9 @@ export const useChat = () => {
     const dispatch = useAppDispatch();
     const { specializations: specializationsState } = useAppSelector((state: RootState) => state.admin);
     const { instance, inProgress } = useMsal();
-    const { conversations, selectedId: currentConversationId } = useAppSelector((state: RootState) => state.conversations);
+    const { conversations, selectedId: currentConversationId } = useAppSelector(
+        (state: RootState) => state.conversations,
+    );
     const { activeUserInfo, features } = useAppSelector((state: RootState) => state.app);
     const { plugins } = useAppSelector((state: RootState) => state.plugins);
 
@@ -133,7 +135,9 @@ export const useChat = () => {
                 },
                 {
                     key: 'specialization',
-                    value: conversations[chatId].specializationId ? conversations[chatId].specializationId : defaultSpecializationId,
+                    value: conversations[chatId].specializationId
+                        ? conversations[chatId].specializationId
+                        : defaultSpecializationId,
                 },
             ],
         };
@@ -148,9 +152,11 @@ export const useChat = () => {
                 await chatService.editChatSepcializationAsync(
                     conversation.id,
                     defaultSpecializationId,
-                    await AuthHelper.getSKaaSAccessToken(instance, inProgress)
+                    await AuthHelper.getSKaaSAccessToken(instance, inProgress),
                 );
-                dispatch(editConversationSpecialization({ id: conversation.id, specializationId: defaultSpecializationId }));
+                dispatch(
+                    editConversationSpecialization({ id: conversation.id, specializationId: defaultSpecializationId }),
+                );
             }
             const askResult = await chatService
                 .getBotResponseAsync(

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -14,6 +14,7 @@ import {
     addConversation,
     addMessageToConversationFromUser,
     deleteConversation,
+    editConversationSpecialization,
     setConversations,
     setSelectedConversation,
     updateBotResponseStatus,
@@ -46,7 +47,7 @@ export const useChat = () => {
     const dispatch = useAppDispatch();
     const { specializations: specializationsState } = useAppSelector((state: RootState) => state.admin);
     const { instance, inProgress } = useMsal();
-    const { conversations } = useAppSelector((state: RootState) => state.conversations);
+    const { conversations, selectedId: currentConversationId } = useAppSelector((state: RootState) => state.conversations);
     const { activeUserInfo, features } = useAppSelector((state: RootState) => state.app);
     const { plugins } = useAppSelector((state: RootState) => state.plugins);
 
@@ -70,7 +71,7 @@ export const useChat = () => {
         if (id === `${chatId}-bot` || id.toLocaleLowerCase() === 'bot') return Constants.bot.profile;
         return users.find((user) => user.id === id);
     };
-    const defaultSpecializationId = '';
+    const defaultSpecializationId = specializationsState.find((a) => a.id === 'general')?.id ?? '';
     const createChat = async (specializationId = defaultSpecializationId) => {
         const chatTitle = `Q-Pilot @ ${new Date().toLocaleString()}`;
         try {
@@ -132,7 +133,7 @@ export const useChat = () => {
                 },
                 {
                     key: 'specialization',
-                    value: conversations[chatId].specializationId ?? defaultSpecializationId,
+                    value: conversations[chatId].specializationId ? conversations[chatId].specializationId : defaultSpecializationId,
                 },
             ],
         };
@@ -142,6 +143,15 @@ export const useChat = () => {
         }
 
         try {
+            const conversation = conversations[currentConversationId];
+            if (!conversation.specializationId) {
+                await chatService.editChatSepcializationAsync(
+                    conversation.id,
+                    defaultSpecializationId,
+                    await AuthHelper.getSKaaSAccessToken(instance, inProgress)
+                );
+                dispatch(editConversationSpecialization({ id: conversation.id, specializationId: defaultSpecializationId }));
+            }
             const askResult = await chatService
                 .getBotResponseAsync(
                     ask,


### PR DESCRIPTION
### Motivation and Context

When a user spawns a new chat, they are prompted to select a specialization. However, the chatbox is not locked before you pick one, so it was possible to send a message without a specializationId. This would throw an exception surrounding retrieving details for a null specialization. 

### Description

* Sending a message into a chat without a specialization will now use the default specializationId for the message body and also send a PATCH request to update the chat's specializationId.
* The defaultSpecializationId is retrieved from the redux state by searching for a hardcoded string of 'general'. It would probably be preferable if this value was not hardcoded, but it is similarly hardcoded in the backend usage for this specialization so I figured this may be acceptable. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
