### PR TITLE
Fix missing scrollbar display for admin page on webkit browsers

### DIFF
--- a/webapp/src/components/admin/specialization/SpecializationManager.tsx
+++ b/webapp/src/components/admin/specialization/SpecializationManager.tsx
@@ -31,6 +31,15 @@ const useClasses = makeStyles({
     scrollableContainer: {
         overflowY: 'auto',
         maxHeight: 'calc(100vh - 100px)', // Adjust this value as needed
+        '&:hover': {
+            '&::-webkit-scrollbar-thumb': {
+                backgroundColor: tokens.colorScrollbarOverlay,
+                visibility: 'visible',
+            },
+        },
+        '&::-webkit-scrollbar-track': {
+            backgroundColor: tokens.colorSubtleBackground,
+        },
         ...shorthands.padding('10px'),
     },
 });


### PR DESCRIPTION
### Motivation and Context

Not reproducible in Firefox, but in Chrome the admin page was missing a visible scrollbar that should appear on hover of the scrollable section similar to other pages in the app.

### Description

I added the missing webkit CSS properties to the SpecialiaztionManager. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
