### PR TITLE
increase the application gateway timeout from 20 to 60 seconds

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,6 +89,7 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
     appgw.ingress.kubernetes.io/ssl-redirect: "true"
+    appgw.ingress.kubernetes.io/request-timeout: "60"
 
 tolerations: []
 affinity: {}


### PR DESCRIPTION
### Description

increase the application gateway timeout from 20 (default) to 60 seconds

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
