### PR TITLE
Backend Test Suite

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -99,6 +99,12 @@ dotnet_style_prefer_compound_assignment = true:suggestion
 # Code quality rules
 dotnet_code_quality_unused_parameters = all:suggestion
 
+[*.test.cs]
+# Allow placing test classes in the same directory as the class to test
+# ie: MyProject/MyClass.cs (MyProject.MyClass) and MyProject/MyClass.test.cs (MyProject.MyClass.Test)
+dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
+
+[*.test.cs]
 [*.cs]
 
 # TODO: enable this but stop "dotnet format" from applying incorrect fixes and introducing a lot of unwanted changes.

--- a/.editorconfig
+++ b/.editorconfig
@@ -99,12 +99,6 @@ dotnet_style_prefer_compound_assignment = true:suggestion
 # Code quality rules
 dotnet_code_quality_unused_parameters = all:suggestion
 
-[*.test.cs]
-# Allow placing test classes in the same directory as the class to test
-# ie: MyProject/MyClass.cs (MyProject.MyClass) and MyProject/MyClass.test.cs (MyProject.MyClass.Test)
-dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
-
-[*.test.cs]
 [*.cs]
 
 # TODO: enable this but stop "dotnet format" from applying incorrect fixes and introducing a lot of unwanted changes.
@@ -373,6 +367,10 @@ csharp_style_prefer_top_level_statements = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 
+[*.test.cs]
+# Allow placing test classes in the same directory as the class to test
+# ie: MyProject/MyClass.cs (MyProject.MyClass) and MyProject/MyClass.test.cs (MyProject.MyClass.Test)
+dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
 
 ###############################
 # Java Coding Conventions     #

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,4 +1,4 @@
-name: dotnet-format
+name: Lint Backend
 
 on:
   pull_request:
@@ -66,7 +66,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Check formatting
+      - name: Check For Lint
         if: steps.find-csproj.outputs.csproj_files != ''
         run: |
           for csproj in ${{ steps.find-csproj.outputs.csproj_files }}; do

--- a/.github/workflows/webapi-test.yml
+++ b/.github/workflows/webapi-test.yml
@@ -1,0 +1,23 @@
+#
+# In the webapi directory run: dotnet test .
+#
+# Dotnet test: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test
+#
+# Testing Library (MSTest): https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest
+# Testing Library Resource: https://testingbot.com/support/getting-started/mstest.html
+#
+# Mocking Library (Moq): https://github.com/devlooped/moq/wiki/Quickstart#matching-arguments
+#
+name: Backend Unit Tests
+on:
+  pull_request:
+    branches: [ main ]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test Runner
+        working-directory: webapi
+        run: |
+          dotnet test .

--- a/.github/workflows/webapi-test.yml
+++ b/.github/workflows/webapi-test.yml
@@ -8,12 +8,12 @@
 #
 # Mocking Library (Moq): https://github.com/devlooped/moq/wiki/Quickstart#matching-arguments
 #
-name: Backend Unit Tests
+name: Test Backend
 on:
   pull_request:
     branches: [ main ]
 jobs:
-  format:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/integration-tests/ChatCopilotIntegrationTests.csproj
+++ b/integration-tests/ChatCopilotIntegrationTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.0.1" />
     <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.70.240803.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.1" />
     <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.17.1" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.5.0-alpha" />
@@ -33,6 +34,9 @@
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.MsGraph" Version="1.5.0-alpha" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.OpenApi" Version="1.5.0-alpha" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Web" Version="1.5.0-alpha" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>

--- a/webapi/Services/QBlobStorage.Test.cs
+++ b/webapi/Services/QBlobStorage.Test.cs
@@ -1,0 +1,114 @@
+﻿using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using CopilotChat.WebApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Copilogics.WebApi.Services
+{
+    [TestClass]
+    public class QBlobStorageTests
+    {
+        [DataRow(true)]
+        [DataRow(false)]
+        [TestMethod]
+        // Tests if the BlobExistsAsync method returns correctly when the blob exists or not
+        public async Task BlobExistsAsync_TestBlobExists(bool exists)
+        {
+            var blobServiceClientMock = new Mock<BlobServiceClient>();
+            var blobContainerClientMock = new Mock<BlobContainerClient>();
+            var blobClientMock = new Mock<BlobClient>();
+
+            blobContainerClientMock
+                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+                .Returns(blobClientMock.Object);
+
+            blobClientMock
+                .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
+                .Returns(Task.FromResult(Azure.Response.FromValue(exists, It.IsAny<Azure.Response>())));
+
+            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+
+            var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+
+            Assert.AreEqual(blobExists, exists);
+        }
+
+        [TestMethod]
+        // Tests if the BlobExistsAsync method returns false when the method throws an error
+        public async Task BlobExistsAsync_TestThrownError()
+        {
+            var blobServiceClientMock = new Mock<BlobServiceClient>();
+            var blobContainerClientMock = new Mock<BlobContainerClient>();
+            var blobClientMock = new Mock<BlobClient>();
+
+            blobContainerClientMock
+                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+                .Throws(new Azure.RequestFailedException("Blob not found"));
+
+            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+
+            var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+
+            Assert.AreEqual(blobExists, false);
+        }
+
+        [TestMethod]
+        // Tests if the AddBlobAsync method returns a URI
+        public async Task AddBlobAsync_ReturnsURI()
+        {
+            var blobServiceClientMock = new Mock<BlobServiceClient>();
+            var blobContainerClientMock = new Mock<BlobContainerClient>();
+            var blobClientMock = new Mock<BlobClient>();
+
+            var blobMock = new Mock<IFormFile>();
+
+            blobMock.Setup(mock => mock.FileName).Returns("file.txt");
+            blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
+
+            blobClientMock.Setup(mock => mock.Uri).Returns(new System.Uri("https://www.example.com/index.html"));
+
+            // Validating that the blob client is created with the correct file name
+            // ie: file$1000-1000-1000-1000.txt
+            blobContainerClientMock
+                .Setup(mock =>
+                    mock.GetBlobClient(
+                        It.IsRegex(
+                            @"file\$\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.txt\b"
+                        )
+                    )
+                )
+                .Returns(blobClientMock.Object);
+
+            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+
+            var uri = await qBlobStorage.AddBlobAsync(blobMock.Object);
+
+            Assert.AreEqual(uri, "https://www.example.com/index.html");
+        }
+
+        [TestMethod]
+        // Tests if the DeleteBlobByURIAsync method returns a URI
+        public async Task DeleteBlobURIAsync_ReturnsURI()
+        {
+            var blobServiceClientMock = new Mock<BlobServiceClient>();
+            var blobContainerClientMock = new Mock<BlobContainerClient>();
+            var blobClientMock = new Mock<BlobClient>();
+
+            blobContainerClientMock
+                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+                .Returns(blobClientMock.Object);
+
+            try
+            {
+                var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+                await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
+            }
+            catch (Azure.RequestFailedException)
+            {
+                Assert.Fail("DeleteBlobURIAsync_ReturnsURI: An exception should not have been thrown.");
+            }
+        }
+    }
+}

--- a/webapi/Services/QBlobStorage.cs
+++ b/webapi/Services/QBlobStorage.cs
@@ -17,11 +17,8 @@ public class QBlobStorage
     // BlobContainerClient which is used to interact with the container's blobs
     private BlobContainerClient _blobContainerClient;
 
-    public QBlobStorage(string connectionString, string containerName)
+    public QBlobStorage(BlobServiceClient blobServiceClient, BlobContainerClient blobContainerClient)
     {
-        BlobServiceClient blobServiceClient = new(connectionString);
-        BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
-
         // Create a new container only if it does not exist
         blobContainerClient.CreateIfNotExists(PublicAccessType.Blob);
 
@@ -68,7 +65,6 @@ public class QBlobStorage
     /// Remove a blob from the storage container by URI
     /// </summary>
     /// <param name="blobURI">Blob Storage URI</param>
-    /// <returns>Deleted blob URI</returns>
     public async Task DeleteBlobByURIAsync(System.Uri blobURI)
     {
         BlobUriBuilder blobUriBuilder = new(blobURI);

--- a/webapi/Services/QBlobStorage.cs
+++ b/webapi/Services/QBlobStorage.cs
@@ -11,18 +11,14 @@ namespace CopilotChat.WebApi.Services;
 /// </summary>
 public class QBlobStorage
 {
-    // BlobServiceClient which is used to create a container client
-    private readonly BlobServiceClient _blobServiceClient;
-
     // BlobContainerClient which is used to interact with the container's blobs
     private BlobContainerClient _blobContainerClient;
 
-    public QBlobStorage(BlobServiceClient blobServiceClient, BlobContainerClient blobContainerClient)
+    public QBlobStorage(BlobContainerClient blobContainerClient)
     {
         // Create a new container only if it does not exist
         blobContainerClient.CreateIfNotExists(PublicAccessType.Blob);
 
-        this._blobServiceClient = blobServiceClient;
         this._blobContainerClient = blobContainerClient;
     }
 

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -1,11 +1,10 @@
 ﻿using System.Threading.Tasks;
 using Azure.Storage.Blobs;
-using CopilotChat.WebApi.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Copilogics.WebApi.Services
+namespace CopilotChat.WebApi.Services
 {
     [TestClass]
     public class QBlobStorageTests

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -89,8 +89,8 @@ namespace Copilogics.WebApi.Services
         }
 
         [TestMethod]
-        // Tests if the DeleteBlobByURIAsync method returns a URI
-        public async Task DeleteBlobURIAsync_ReturnsURI()
+        // Tests if the DeleteBlobByURIAsync method does not throw
+        public async Task DeleteBlobURIAsync_DoesNotThrow()
         {
             var blobServiceClientMock = new Mock<BlobServiceClient>();
             var blobContainerClientMock = new Mock<BlobContainerClient>();

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -4,10 +4,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace CopilotChat.WebApi.Services.Tests;
+namespace CopilotChat.WebApi.Services.Test;
 
 [TestClass]
-public class QBlobStorageTests
+public class QBlobStorageTest
 {
     [DataRow(true)]
     [DataRow(false)]
@@ -18,7 +18,9 @@ public class QBlobStorageTests
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
+        blobContainerClientMock
+            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
 
         blobClientMock
             .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
@@ -26,7 +28,9 @@ public class QBlobStorageTests
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+        var blobExists = await qBlobStorage.BlobExistsAsync(
+            new System.Uri("https://www.example.com/index.html")
+        );
 
         Assert.AreEqual(blobExists, exists);
     }
@@ -44,7 +48,9 @@ public class QBlobStorageTests
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+        var blobExists = await qBlobStorage.BlobExistsAsync(
+            new System.Uri("https://www.example.com/index.html")
+        );
 
         Assert.AreEqual(blobExists, false);
     }
@@ -61,7 +67,9 @@ public class QBlobStorageTests
         blobMock.Setup(mock => mock.FileName).Returns("file.txt");
         blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
 
-        blobClientMock.Setup(mock => mock.Uri).Returns(new System.Uri("https://www.example.com/index.html"));
+        blobClientMock
+            .Setup(mock => mock.Uri)
+            .Returns(new System.Uri("https://www.example.com/index.html"));
 
         // Validating that the blob client is created with the correct file name
         // ie: file$1000-1000-1000-1000.txt
@@ -89,12 +97,16 @@ public class QBlobStorageTests
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
+        blobContainerClientMock
+            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
 
         try
         {
             var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
-            await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
+            await qBlobStorage.DeleteBlobByURIAsync(
+                new System.Uri("https://www.example.com/index.html")
+            );
         }
         catch (Azure.RequestFailedException)
         {

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -16,7 +16,6 @@ namespace Copilogics.WebApi.Services
         // Tests if the BlobExistsAsync method returns correctly when the blob exists or not
         public async Task BlobExistsAsync_TestBlobExists(bool exists)
         {
-            var blobServiceClientMock = new Mock<BlobServiceClient>();
             var blobContainerClientMock = new Mock<BlobContainerClient>();
             var blobClientMock = new Mock<BlobClient>();
 
@@ -28,7 +27,7 @@ namespace Copilogics.WebApi.Services
                 .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
                 .Returns(Task.FromResult(Azure.Response.FromValue(exists, It.IsAny<Azure.Response>())));
 
-            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
             var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
@@ -39,7 +38,6 @@ namespace Copilogics.WebApi.Services
         // Tests if the BlobExistsAsync method returns false when the method throws an error
         public async Task BlobExistsAsync_TestThrownError()
         {
-            var blobServiceClientMock = new Mock<BlobServiceClient>();
             var blobContainerClientMock = new Mock<BlobContainerClient>();
             var blobClientMock = new Mock<BlobClient>();
 
@@ -47,7 +45,7 @@ namespace Copilogics.WebApi.Services
                 .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
                 .Throws(new Azure.RequestFailedException("Blob not found"));
 
-            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
             var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
@@ -58,7 +56,6 @@ namespace Copilogics.WebApi.Services
         // Tests if the AddBlobAsync method returns a URI
         public async Task AddBlobAsync_ReturnsURI()
         {
-            var blobServiceClientMock = new Mock<BlobServiceClient>();
             var blobContainerClientMock = new Mock<BlobContainerClient>();
             var blobClientMock = new Mock<BlobClient>();
 
@@ -81,7 +78,7 @@ namespace Copilogics.WebApi.Services
                 )
                 .Returns(blobClientMock.Object);
 
-            var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
             var uri = await qBlobStorage.AddBlobAsync(blobMock.Object);
 
@@ -92,7 +89,6 @@ namespace Copilogics.WebApi.Services
         // Tests if the DeleteBlobByURIAsync method does not throw
         public async Task DeleteBlobURIAsync_DoesNotThrow()
         {
-            var blobServiceClientMock = new Mock<BlobServiceClient>();
             var blobContainerClientMock = new Mock<BlobContainerClient>();
             var blobClientMock = new Mock<BlobClient>();
 
@@ -102,7 +98,7 @@ namespace Copilogics.WebApi.Services
 
             try
             {
-                var qBlobStorage = new QBlobStorage(blobServiceClientMock.Object, blobContainerClientMock.Object);
+                var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
                 await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
             }
             catch (Azure.RequestFailedException)

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -1,109 +1,115 @@
 ﻿using System.Threading.Tasks;
 using Azure.Storage.Blobs;
+using CopilotChat.WebApi.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace CopilotChat.WebApi.Services
+[TestClass]
+public class QBlobStorageTests
 {
-    [TestClass]
-    public class QBlobStorageTests
+    [DataRow(true)]
+    [DataRow(false)]
+    [TestMethod]
+    // Tests if the BlobExistsAsync method returns correctly when the blob exists or not
+    public async Task BlobExistsAsync_TestBlobExists(bool exists)
     {
-        [DataRow(true)]
-        [DataRow(false)]
-        [TestMethod]
-        // Tests if the BlobExistsAsync method returns correctly when the blob exists or not
-        public async Task BlobExistsAsync_TestBlobExists(bool exists)
-        {
-            var blobContainerClientMock = new Mock<BlobContainerClient>();
-            var blobClientMock = new Mock<BlobClient>();
+        var blobContainerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
 
-            blobContainerClientMock
-                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-                .Returns(blobClientMock.Object);
+        blobContainerClientMock
+            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
 
-            blobClientMock
-                .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
-                .Returns(Task.FromResult(Azure.Response.FromValue(exists, It.IsAny<Azure.Response>())));
+        blobClientMock
+            .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
+            .Returns(Task.FromResult(Azure.Response.FromValue(exists, It.IsAny<Azure.Response>())));
 
-            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
+        var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-            var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+        var blobExists = await qBlobStorage.BlobExistsAsync(
+            new System.Uri("https://www.example.com/index.html")
+        );
 
-            Assert.AreEqual(blobExists, exists);
-        }
+        Assert.AreEqual(blobExists, exists);
+    }
 
-        [TestMethod]
-        // Tests if the BlobExistsAsync method returns false when the method throws an error
-        public async Task BlobExistsAsync_TestThrownError()
-        {
-            var blobContainerClientMock = new Mock<BlobContainerClient>();
-            var blobClientMock = new Mock<BlobClient>();
+    [TestMethod]
+    // Tests if the BlobExistsAsync method returns false when the method throws an error
+    public async Task BlobExistsAsync_TestThrownError()
+    {
+        var blobContainerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
 
-            blobContainerClientMock
-                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-                .Throws(new Azure.RequestFailedException("Blob not found"));
+        blobContainerClientMock
+            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+            .Throws(new Azure.RequestFailedException("Blob not found"));
 
-            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
+        var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-            var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
+        var blobExists = await qBlobStorage.BlobExistsAsync(
+            new System.Uri("https://www.example.com/index.html")
+        );
 
-            Assert.AreEqual(blobExists, false);
-        }
+        Assert.AreEqual(blobExists, false);
+    }
 
-        [TestMethod]
-        // Tests if the AddBlobAsync method returns a URI
-        public async Task AddBlobAsync_ReturnsURI()
-        {
-            var blobContainerClientMock = new Mock<BlobContainerClient>();
-            var blobClientMock = new Mock<BlobClient>();
+    [TestMethod]
+    // Tests if the AddBlobAsync method returns a URI
+    public async Task AddBlobAsync_ReturnsURI()
+    {
+        var blobContainerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
 
-            var blobMock = new Mock<IFormFile>();
+        var blobMock = new Mock<IFormFile>();
 
-            blobMock.Setup(mock => mock.FileName).Returns("file.txt");
-            blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
+        blobMock.Setup(mock => mock.FileName).Returns("file.txt");
+        blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
 
-            blobClientMock.Setup(mock => mock.Uri).Returns(new System.Uri("https://www.example.com/index.html"));
+        blobClientMock
+            .Setup(mock => mock.Uri)
+            .Returns(new System.Uri("https://www.example.com/index.html"));
 
-            // Validating that the blob client is created with the correct file name
-            // ie: file$1000-1000-1000-1000.txt
-            blobContainerClientMock
-                .Setup(mock =>
-                    mock.GetBlobClient(
-                        It.IsRegex(
-                            @"file\$\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.txt\b"
-                        )
+        // Validating that the blob client is created with the correct file name
+        // ie: file$1000-1000-1000-1000.txt
+        blobContainerClientMock
+            .Setup(mock =>
+                mock.GetBlobClient(
+                    It.IsRegex(
+                        @"file\$\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.txt\b"
                     )
                 )
-                .Returns(blobClientMock.Object);
+            )
+            .Returns(blobClientMock.Object);
 
-            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
+        var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-            var uri = await qBlobStorage.AddBlobAsync(blobMock.Object);
+        var uri = await qBlobStorage.AddBlobAsync(blobMock.Object);
 
-            Assert.AreEqual(uri, "https://www.example.com/index.html");
-        }
+        Assert.AreEqual(uri, "https://www.example.com/index.html");
+    }
 
-        [TestMethod]
-        // Tests if the DeleteBlobByURIAsync method does not throw
-        public async Task DeleteBlobURIAsync_DoesNotThrow()
+    [TestMethod]
+    // Tests if the DeleteBlobByURIAsync method does not throw
+    public async Task DeleteBlobURIAsync_DoesNotThrow()
+    {
+        var blobContainerClientMock = new Mock<BlobContainerClient>();
+        var blobClientMock = new Mock<BlobClient>();
+
+        blobContainerClientMock
+            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobClientMock.Object);
+
+        try
         {
-            var blobContainerClientMock = new Mock<BlobContainerClient>();
-            var blobClientMock = new Mock<BlobClient>();
-
-            blobContainerClientMock
-                .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-                .Returns(blobClientMock.Object);
-
-            try
-            {
-                var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
-                await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
-            }
-            catch (Azure.RequestFailedException)
-            {
-                Assert.Fail("DeleteBlobURIAsync_ReturnsURI: An exception should not have been thrown.");
-            }
+            var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
+            await qBlobStorage.DeleteBlobByURIAsync(
+                new System.Uri("https://www.example.com/index.html")
+            );
+        }
+        catch (Azure.RequestFailedException)
+        {
+            Assert.Fail("DeleteBlobURIAsync_ReturnsURI: An exception should not have been thrown.");
         }
     }
 }

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -1,9 +1,10 @@
 ﻿using System.Threading.Tasks;
 using Azure.Storage.Blobs;
-using CopilotChat.WebApi.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+
+namespace CopilotChat.WebApi.Services.Tests;
 
 [TestClass]
 public class QBlobStorageTests
@@ -17,9 +18,7 @@ public class QBlobStorageTests
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock
-            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-            .Returns(blobClientMock.Object);
+        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
 
         blobClientMock
             .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
@@ -27,9 +26,7 @@ public class QBlobStorageTests
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(
-            new System.Uri("https://www.example.com/index.html")
-        );
+        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
         Assert.AreEqual(blobExists, exists);
     }
@@ -47,9 +44,7 @@ public class QBlobStorageTests
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(
-            new System.Uri("https://www.example.com/index.html")
-        );
+        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
         Assert.AreEqual(blobExists, false);
     }
@@ -66,9 +61,7 @@ public class QBlobStorageTests
         blobMock.Setup(mock => mock.FileName).Returns("file.txt");
         blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
 
-        blobClientMock
-            .Setup(mock => mock.Uri)
-            .Returns(new System.Uri("https://www.example.com/index.html"));
+        blobClientMock.Setup(mock => mock.Uri).Returns(new System.Uri("https://www.example.com/index.html"));
 
         // Validating that the blob client is created with the correct file name
         // ie: file$1000-1000-1000-1000.txt
@@ -96,16 +89,12 @@ public class QBlobStorageTests
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock
-            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-            .Returns(blobClientMock.Object);
+        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
 
         try
         {
             var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
-            await qBlobStorage.DeleteBlobByURIAsync(
-                new System.Uri("https://www.example.com/index.html")
-            );
+            await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
         }
         catch (Azure.RequestFailedException)
         {

--- a/webapi/Services/QBlobStorage.test.cs
+++ b/webapi/Services/QBlobStorage.test.cs
@@ -18,9 +18,7 @@ public class QBlobStorageTest
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock
-            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-            .Returns(blobClientMock.Object);
+        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
 
         blobClientMock
             .Setup(mock => mock.ExistsAsync(It.IsAny<System.Threading.CancellationToken>()))
@@ -28,9 +26,7 @@ public class QBlobStorageTest
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(
-            new System.Uri("https://www.example.com/index.html")
-        );
+        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
         Assert.AreEqual(blobExists, exists);
     }
@@ -48,9 +44,7 @@ public class QBlobStorageTest
 
         var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
 
-        var blobExists = await qBlobStorage.BlobExistsAsync(
-            new System.Uri("https://www.example.com/index.html")
-        );
+        var blobExists = await qBlobStorage.BlobExistsAsync(new System.Uri("https://www.example.com/index.html"));
 
         Assert.AreEqual(blobExists, false);
     }
@@ -67,9 +61,7 @@ public class QBlobStorageTest
         blobMock.Setup(mock => mock.FileName).Returns("file.txt");
         blobMock.Setup(mock => mock.OpenReadStream()).Returns(new System.IO.MemoryStream());
 
-        blobClientMock
-            .Setup(mock => mock.Uri)
-            .Returns(new System.Uri("https://www.example.com/index.html"));
+        blobClientMock.Setup(mock => mock.Uri).Returns(new System.Uri("https://www.example.com/index.html"));
 
         // Validating that the blob client is created with the correct file name
         // ie: file$1000-1000-1000-1000.txt
@@ -97,16 +89,12 @@ public class QBlobStorageTest
         var blobContainerClientMock = new Mock<BlobContainerClient>();
         var blobClientMock = new Mock<BlobClient>();
 
-        blobContainerClientMock
-            .Setup(mock => mock.GetBlobClient(It.IsAny<string>()))
-            .Returns(blobClientMock.Object);
+        blobContainerClientMock.Setup(mock => mock.GetBlobClient(It.IsAny<string>())).Returns(blobClientMock.Object);
 
         try
         {
             var qBlobStorage = new QBlobStorage(blobContainerClientMock.Object);
-            await qBlobStorage.DeleteBlobByURIAsync(
-                new System.Uri("https://www.example.com/index.html")
-            );
+            await qBlobStorage.DeleteBlobByURIAsync(new System.Uri("https://www.example.com/index.html"));
         }
         catch (Azure.RequestFailedException)
         {

--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -31,8 +31,7 @@ public class QSpecializationService : IQSpecializationService
         this._specializationSourceRepository = specializationSourceRepository;
         this._qAzureOpenAIChatOptions = qAzureOpenAIChatOptions;
 
-        BlobServiceClient blobServiceClient =
-            new(qAzureOpenAIChatOptions.BlobStorage.ConnectionString);
+        BlobServiceClient blobServiceClient = new(qAzureOpenAIChatOptions.BlobStorage.ConnectionString);
 
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(
             qAzureOpenAIChatOptions.BlobStorage.SpecializationContainerName
@@ -65,9 +64,7 @@ public class QSpecializationService : IQSpecializationService
     /// </summary>
     /// <param name="qSpecializationMutate">Specialization mutate payload</param>
     /// <returns>The task result contains the specialization source</returns>
-    public async Task<Specialization> SaveSpecialization(
-        QSpecializationMutate qSpecializationMutate
-    )
+    public async Task<Specialization> SaveSpecialization(QSpecializationMutate qSpecializationMutate)
     {
         // Add the image to the blob storage or use the default image
         var imageFilePath =
@@ -110,8 +107,9 @@ public class QSpecializationService : IQSpecializationService
         QSpecializationMutate qSpecializationMutate
     )
     {
-        Specialization? specializationToUpdate =
-            await this._specializationSourceRepository.FindByIdAsync(specializationId.ToString());
+        Specialization? specializationToUpdate = await this._specializationSourceRepository.FindByIdAsync(
+            specializationId.ToString()
+        );
 
         if (specializationToUpdate != null)
         {
@@ -137,15 +135,11 @@ public class QSpecializationService : IQSpecializationService
                 ? qSpecializationMutate.Name
                 : specializationToUpdate!.Name;
 
-            specializationToUpdate!.Description = !string.IsNullOrEmpty(
-                qSpecializationMutate.Description
-            )
+            specializationToUpdate!.Description = !string.IsNullOrEmpty(qSpecializationMutate.Description)
                 ? qSpecializationMutate.Description
                 : specializationToUpdate!.Description;
 
-            specializationToUpdate!.RoleInformation = !string.IsNullOrEmpty(
-                qSpecializationMutate.RoleInformation
-            )
+            specializationToUpdate!.RoleInformation = !string.IsNullOrEmpty(qSpecializationMutate.RoleInformation)
                 ? qSpecializationMutate.RoleInformation
                 : specializationToUpdate!.RoleInformation;
 
@@ -155,9 +149,7 @@ public class QSpecializationService : IQSpecializationService
                     : specializationToUpdate!.IndexName;
 
             // Group memberships (mutate payload) are a comma separated list of UUIDs.
-            specializationToUpdate!.GroupMemberships = !string.IsNullOrEmpty(
-                qSpecializationMutate.GroupMemberships
-            )
+            specializationToUpdate!.GroupMemberships = !string.IsNullOrEmpty(qSpecializationMutate.GroupMemberships)
                 ? qSpecializationMutate.GroupMemberships.Split(',')
                 : specializationToUpdate!.GroupMemberships;
 
@@ -181,8 +173,9 @@ public class QSpecializationService : IQSpecializationService
     /// <returns>The task result contains the delete state</returns>
     public async Task<bool> DeleteSpecialization(Guid specializationId)
     {
-        Specialization? specializationToDelete =
-            await this._specializationSourceRepository.FindByIdAsync(specializationId.ToString());
+        Specialization? specializationToDelete = await this._specializationSourceRepository.FindByIdAsync(
+            specializationId.ToString()
+        );
 
         await this._specializationSourceRepository.DeleteAsync(specializationToDelete);
 

--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -31,12 +31,15 @@ public class QSpecializationService : IQSpecializationService
         this._specializationSourceRepository = specializationSourceRepository;
         this._qAzureOpenAIChatOptions = qAzureOpenAIChatOptions;
 
-        BlobServiceClient blobServiceClient = new(qAzureOpenAIChatOptions.BlobStorage.ConnectionString);
+        BlobServiceClient blobServiceClient = new BlobServiceClient(
+            qAzureOpenAIChatOptions.BlobStorage.ConnectionString
+        );
+
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(
             qAzureOpenAIChatOptions.BlobStorage.SpecializationContainerName
         );
 
-        this._qBlobStorage = new QBlobStorage(blobServiceClient, blobContainerClient);
+        this._qBlobStorage = new QBlobStorage(blobContainerClient);
     }
 
     /// <summary>

--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs;
 using CopilotChat.WebApi.Models.Request;
 using CopilotChat.WebApi.Models.Storage;
 using CopilotChat.WebApi.Plugins.Chat.Ext;
@@ -29,10 +30,13 @@ public class QSpecializationService : IQSpecializationService
     {
         this._specializationSourceRepository = specializationSourceRepository;
         this._qAzureOpenAIChatOptions = qAzureOpenAIChatOptions;
-        this._qBlobStorage = new QBlobStorage(
-            qAzureOpenAIChatOptions.BlobStorage.ConnectionString,
+
+        BlobServiceClient blobServiceClient = new(qAzureOpenAIChatOptions.BlobStorage.ConnectionString);
+        BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(
             qAzureOpenAIChatOptions.BlobStorage.SpecializationContainerName
         );
+
+        this._qBlobStorage = new QBlobStorage(blobServiceClient, blobContainerClient);
     }
 
     /// <summary>

--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -31,9 +31,8 @@ public class QSpecializationService : IQSpecializationService
         this._specializationSourceRepository = specializationSourceRepository;
         this._qAzureOpenAIChatOptions = qAzureOpenAIChatOptions;
 
-        BlobServiceClient blobServiceClient = new BlobServiceClient(
-            qAzureOpenAIChatOptions.BlobStorage.ConnectionString
-        );
+        BlobServiceClient blobServiceClient =
+            new(qAzureOpenAIChatOptions.BlobStorage.ConnectionString);
 
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(
             qAzureOpenAIChatOptions.BlobStorage.SpecializationContainerName
@@ -66,7 +65,9 @@ public class QSpecializationService : IQSpecializationService
     /// </summary>
     /// <param name="qSpecializationMutate">Specialization mutate payload</param>
     /// <returns>The task result contains the specialization source</returns>
-    public async Task<Specialization> SaveSpecialization(QSpecializationMutate qSpecializationMutate)
+    public async Task<Specialization> SaveSpecialization(
+        QSpecializationMutate qSpecializationMutate
+    )
     {
         // Add the image to the blob storage or use the default image
         var imageFilePath =
@@ -109,9 +110,8 @@ public class QSpecializationService : IQSpecializationService
         QSpecializationMutate qSpecializationMutate
     )
     {
-        Specialization? specializationToUpdate = await this._specializationSourceRepository.FindByIdAsync(
-            specializationId.ToString()
-        );
+        Specialization? specializationToUpdate =
+            await this._specializationSourceRepository.FindByIdAsync(specializationId.ToString());
 
         if (specializationToUpdate != null)
         {
@@ -137,11 +137,15 @@ public class QSpecializationService : IQSpecializationService
                 ? qSpecializationMutate.Name
                 : specializationToUpdate!.Name;
 
-            specializationToUpdate!.Description = !string.IsNullOrEmpty(qSpecializationMutate.Description)
+            specializationToUpdate!.Description = !string.IsNullOrEmpty(
+                qSpecializationMutate.Description
+            )
                 ? qSpecializationMutate.Description
                 : specializationToUpdate!.Description;
 
-            specializationToUpdate!.RoleInformation = !string.IsNullOrEmpty(qSpecializationMutate.RoleInformation)
+            specializationToUpdate!.RoleInformation = !string.IsNullOrEmpty(
+                qSpecializationMutate.RoleInformation
+            )
                 ? qSpecializationMutate.RoleInformation
                 : specializationToUpdate!.RoleInformation;
 
@@ -151,7 +155,9 @@ public class QSpecializationService : IQSpecializationService
                     : specializationToUpdate!.IndexName;
 
             // Group memberships (mutate payload) are a comma separated list of UUIDs.
-            specializationToUpdate!.GroupMemberships = !string.IsNullOrEmpty(qSpecializationMutate.GroupMemberships)
+            specializationToUpdate!.GroupMemberships = !string.IsNullOrEmpty(
+                qSpecializationMutate.GroupMemberships
+            )
                 ? qSpecializationMutate.GroupMemberships.Split(',')
                 : specializationToUpdate!.GroupMemberships;
 
@@ -175,9 +181,8 @@ public class QSpecializationService : IQSpecializationService
     /// <returns>The task result contains the delete state</returns>
     public async Task<bool> DeleteSpecialization(Guid specializationId)
     {
-        Specialization? specializationToDelete = await this._specializationSourceRepository.FindByIdAsync(
-            specializationId.ToString()
-        );
+        Specialization? specializationToDelete =
+            await this._specializationSourceRepository.FindByIdAsync(specializationId.ToString());
 
         await this._specializationSourceRepository.DeleteAsync(specializationToDelete);
 


### PR DESCRIPTION
### Motivation and Context
- No test suite exists for backend (WebApi)

- Note: This does not include anything related to "Coverage". But happy to do a github action for that if needed in the future.

Some thoughts I had about strategies for increasing coverage in the codebase:
1. Set repository variable that is used to set the coverage action threshold. Repository admins could then manually increment.
2. Some automation that manually sets the coverage percent by (n) for each new PR. Slowly increasing coverage percentage as more code is added.
3. Hard-code some reasonable threshold into the action, and update manually with PR's. We would need to set it to something very small to begin with.


<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  4. What problem does it solve?
  5. What scenario does it contribute to?
  6. If it fixes an open issue, please link to the issue here.
-->

### Description
- Added Github action for running WebAPI tests
- Created example test class
- Updated the .editorconfig to ignore specific warning about namespaces
- Added new packages for testing, MsTest / Moq (Mocking library)
- Bumped MsTest version for integration tests (currently these are not being used, but could be in the future)
- Re-structured an existing class to make it easier to test (QBlobStorage)

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
