### PR TITLE
Add suggestion topics when starting a new chat

### DIFF
--- a/webapi/Controllers/ChatController.cs
+++ b/webapi/Controllers/ChatController.cs
@@ -53,6 +53,7 @@ public class ChatController : ControllerBase, IDisposable
 
     private const string ChatPluginName = nameof(ChatPlugin);
     private const string ChatFunctionName = "Chat";
+    private const string SilentChatFunctionName = "ChatSilent";
     private const string GeneratingResponseClientCall = "ReceiveBotResponseStatus";
 
     public ChatController(
@@ -154,6 +155,105 @@ public class ChatController : ControllerBase, IDisposable
             }
 
             this._telemetryService.TrackPluginFunction(ChatPluginName, ChatFunctionName, false);
+
+            throw;
+        }
+
+        AskResult chatAskResult =
+            new()
+            {
+                Value = result.ToString() ?? string.Empty,
+                Variables = contextVariables.Select(v => new KeyValuePair<string, object?>(v.Key, v.Value)),
+            };
+
+        // Broadcast AskResult to all users
+        await messageRelayHubContext
+            .Clients.Group(chatIdString)
+            .SendAsync(GeneratingResponseClientCall, chatIdString, null);
+
+        return this.Ok(chatAskResult);
+    }
+
+    /// <summary>
+    /// Invokes the chat function to get a response from the bot.
+    /// </summary>
+    /// <param name="kernel">Semantic kernel obtained through dependency injection.</param>
+    /// <param name="messageRelayHubContext">Message Hub that performs the real time relay service.</param>
+    /// <param name="chatSessionRepository">Repository of chat sessions.</param>
+    /// <param name="chatParticipantRepository">Repository of chat participants.</param>
+    /// <param name="authInfo">Auth info for the current request.</param>
+    /// <param name="ask">Prompt along with its parameters.</param>
+    /// <param name="chatId">Chat ID.</param>
+    /// <returns>Results containing the response from the model.</returns>
+    [Route("chats/{chatId:guid}/messages/silent")]
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status504GatewayTimeout)]
+    public async Task<IActionResult> ChatSilentAsync(
+        [FromServices] Kernel kernel,
+        [FromServices] IHubContext<MessageRelayHub> messageRelayHubContext,
+        [FromServices] ChatSessionRepository chatSessionRepository,
+        [FromServices] ChatParticipantRepository chatParticipantRepository,
+        [FromServices] IAuthInfo authInfo,
+        [FromBody] Ask ask,
+        [FromRoute] Guid chatId
+    )
+    {
+        this._logger.LogDebug("Chat message received.");
+
+        string chatIdString = chatId.ToString();
+
+        // Put ask's variables in the context we will use.
+        var contextVariables = GetContextVariables(ask, authInfo, chatIdString);
+
+        // Verify that the chat exists and that the user has access to it.
+        ChatSession? chat = null;
+        if (!(await chatSessionRepository.TryFindByIdAsync(chatIdString, callback: c => chat = c)))
+        {
+            return this.NotFound("Failed to find chat session for the chatId specified in variables.");
+        }
+
+        if (!(await chatParticipantRepository.IsUserInChatAsync(authInfo.UserId, chatIdString)))
+        {
+            return this.Forbid("User does not have access to the chatId specified in variables.");
+        }
+
+        // Register plugins that have been enabled
+        var openApiPluginAuthHeaders = this.GetPluginAuthHeaders(this.HttpContext.Request.Headers);
+        await this.RegisterFunctionsAsync(kernel, openApiPluginAuthHeaders, contextVariables);
+
+        // Register hosted plugins that have been enabled
+        await this.RegisterHostedFunctionsAsync(kernel, chat!.EnabledPlugins);
+
+        // Get the function to invoke
+        KernelFunction? chatFunction = kernel.Plugins.GetFunction(ChatPluginName, SilentChatFunctionName);
+        var computed = nameof(chatFunction);
+        Console.WriteLine($"Got chat function with const name {SilentChatFunctionName} and computed {computed}");
+        // Run the function.
+        FunctionResult? result = null;
+        try
+        {
+            using CancellationTokenSource? cts = this._serviceOptions.TimeoutLimitInS is not null
+                // Create a cancellation token source with the timeout if specified
+                ? new CancellationTokenSource(TimeSpan.FromSeconds((double)this._serviceOptions.TimeoutLimitInS))
+                : null;
+
+            result = await kernel.InvokeAsync(chatFunction!, contextVariables, cts?.Token ?? default);
+            this._telemetryService.TrackPluginFunction(ChatPluginName, SilentChatFunctionName, true);
+        }
+        catch (Exception ex)
+        {
+            if (ex is OperationCanceledException || ex.InnerException is OperationCanceledException)
+            {
+                // Log the timeout and return a 504 response
+                this._logger.LogError("The {FunctionName} operation timed out.", SilentChatFunctionName);
+                return this.StatusCode(StatusCodes.Status504GatewayTimeout, $"The chat {SilentChatFunctionName} timed out.");
+            }
+
+            this._telemetryService.TrackPluginFunction(ChatPluginName, SilentChatFunctionName, false);
 
             throw;
         }

--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -292,9 +292,6 @@ public class ChatPlugin
         // Set the system description in the prompt options
         await this.SetSystemDescriptionAsync(chatId, cancellationToken);
 
-        // Save this new message to memory such that subsequent chat responses can use it
-        await this.UpdateBotResponseStatusOnClientAsync(chatId, "Generating bot response", cancellationToken);
-
         var newUserMessage = new CopilotChatMessage(
             userId,
             userName,

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -10,6 +10,7 @@ import { FeatureKeys, Features } from '../../redux/features/app/AppState';
 import { SharedStyles } from '../../styles';
 import { ChatInput } from './ChatInput';
 import { ChatHistory } from './chat-history/ChatHistory';
+import { ChatSuggestionList } from './suggestions/ChatSuggestionList';
 
 const useClasses = makeStyles({
     root: {
@@ -35,6 +36,10 @@ const useClasses = makeStyles({
         flexDirection: 'row',
         justifyContent: 'center',
         ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingVerticalNone),
+    },
+    suggestions: {
+        display: 'flex',
+        flexDirection: 'row',
     },
     carouselroot: {
         display: 'flex',
@@ -140,7 +145,9 @@ export const ChatRoom: React.FC = () => {
                     </div>
                 </div>
             )}
-
+            <div className={classes.suggestions}>
+                <ChatSuggestionList />
+            </div>
             <div className={classes.input}>
                 <ChatInput isDraggingOver={isDraggingOver} onDragLeave={onDragLeave} onSubmit={handleSubmit} />
             </div>

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -4,6 +4,7 @@ import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import React, { useState } from 'react';
 import { SpecializationCardList } from '../../components/specialization/SpecializationCardList';
 import { GetResponseOptions, useChat } from '../../libs/hooks/useChat';
+import { ChatMessageType } from '../../libs/models/ChatMessage';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 import { FeatureKeys, Features } from '../../redux/features/app/AppState';
@@ -76,6 +77,7 @@ export const ChatRoom: React.FC = () => {
     const { specializations } = useAppSelector((state: RootState) => state.admin);
 
     const [showSpecialization, setShowSpecialization] = useState(true);
+    const [showSuggestions, setShowSuggestions] = useState(true);
 
     React.useEffect(() => {
         if (!shouldAutoScroll) return;
@@ -101,6 +103,10 @@ export const ChatRoom: React.FC = () => {
     }, []);
 
     React.useEffect(() => {
+        if (Object.keys(messages).length <= 1) {
+            setShowSuggestions(true);
+        }
+
         if (Object.keys(messages).length <= 1 && conversations[selectedId].specializationId === '') {
             setShowSpecialization(true);
         } else {
@@ -112,6 +118,16 @@ export const ChatRoom: React.FC = () => {
         await chat.getResponse(options);
         setShouldAutoScroll(true);
     };
+
+    const suggestionClick = (message: string) => {
+         const messageBody: GetResponseOptions = {
+            messageType: ChatMessageType.Message,
+            value: message,
+            chatId: selectedId
+        }
+        void chat.getResponse(messageBody);
+        setShowSuggestions(false);
+    }
 
     if (conversations[selectedId].hidden) {
         return (
@@ -145,9 +161,12 @@ export const ChatRoom: React.FC = () => {
                     </div>
                 </div>
             )}
-            <div className={classes.suggestions}>
-                <ChatSuggestionList />
-            </div>
+            {showSuggestions && (
+                <div className={classes.suggestions}>
+                    <ChatSuggestionList onClickSuggestion={suggestionClick} />
+                </div>
+            )
+            }
             <div className={classes.input}>
                 <ChatInput isDraggingOver={isDraggingOver} onDragLeave={onDragLeave} onSubmit={handleSubmit} />
             </div>

--- a/webapp/src/components/chat/suggestions/ChatSuggestion.tsx
+++ b/webapp/src/components/chat/suggestions/ChatSuggestion.tsx
@@ -1,0 +1,78 @@
+import { Card, CardHeader, Text, makeStyles, tokens } from "@fluentui/react-components";
+import React from "react";
+import { useChat } from "../../../libs/hooks";
+import { GetResponseOptions } from "../../../libs/hooks/useChat";
+import { ChatMessageType } from "../../../libs/models/ChatMessage";
+import { useAppSelector } from "../../../redux/app/hooks";
+import { RootState } from "../../../redux/app/store";
+
+const useStyles = makeStyles({
+    main: {
+        display: 'flex',
+        flexWrap: 'wrap',
+    },
+
+    card: {
+        maxWidth: '250px',
+        height: '100px',
+    },
+
+    root: {
+        padding: tokens.spacingHorizontalS,
+    },
+
+    caption: {
+        color: tokens.colorNeutralForeground3,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+
+    smallRadius: { borderRadius: tokens.borderRadiusSmall },
+
+    grayBackground: {
+        backgroundColor: tokens.colorNeutralBackground3,
+    },
+
+    logoBadge: {
+        padding: '5px',
+        borderRadius: tokens.borderRadiusSmall,
+        backgroundColor: '#FFF',
+        boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12)',
+    },
+
+    showTooltip: {
+        display: 'show',
+    },
+
+    hideTooltip: {
+        display: 'none',
+    },
+});
+
+interface ChatSuggestionProps {
+  suggestionTitleText: string;
+  suggestionMainText: string;
+}
+
+export const ChatSuggestion: React.FC<ChatSuggestionProps> = ({ suggestionMainText}) => {
+  const styles = useStyles();
+  const chat = useChat();
+  const converstationState = useAppSelector((state: RootState) => state.conversations);
+  const suggestionDivID = React.useId();
+  const cardId = React.useId();
+  const onSendSuggestion = () => {
+    const messageBody: GetResponseOptions = {
+      messageType: ChatMessageType.Message,
+      value: suggestionMainText,
+      chatId: converstationState.selectedId
+    }
+    void chat.getResponse(messageBody);
+  }
+  return (
+    <div className={ styles.root } key={suggestionDivID}>
+      <Card className={styles.card} data-testid="chatSuggestionItem" onClick={onSendSuggestion} key={cardId}>
+        <CardHeader header={<Text weight="semibold">{suggestionMainText}</Text>}/>
+      </Card>
+    </div>
+  )
+}

--- a/webapp/src/components/chat/suggestions/ChatSuggestion.tsx
+++ b/webapp/src/components/chat/suggestions/ChatSuggestion.tsx
@@ -1,10 +1,5 @@
 import { Card, CardHeader, Text, makeStyles, tokens } from "@fluentui/react-components";
 import React from "react";
-import { useChat } from "../../../libs/hooks";
-import { GetResponseOptions } from "../../../libs/hooks/useChat";
-import { ChatMessageType } from "../../../libs/models/ChatMessage";
-import { useAppSelector } from "../../../redux/app/hooks";
-import { RootState } from "../../../redux/app/store";
 
 const useStyles = makeStyles({
     main: {
@@ -50,27 +45,18 @@ const useStyles = makeStyles({
 });
 
 interface ChatSuggestionProps {
-  suggestionTitleText: string;
+  onClick: (message: string) => void;
   suggestionMainText: string;
 }
 
-export const ChatSuggestion: React.FC<ChatSuggestionProps> = ({ suggestionMainText}) => {
+export const ChatSuggestion: React.FC<ChatSuggestionProps> = ({ suggestionMainText, onClick }) => {
   const styles = useStyles();
-  const chat = useChat();
-  const converstationState = useAppSelector((state: RootState) => state.conversations);
   const suggestionDivID = React.useId();
   const cardId = React.useId();
-  const onSendSuggestion = () => {
-    const messageBody: GetResponseOptions = {
-      messageType: ChatMessageType.Message,
-      value: suggestionMainText,
-      chatId: converstationState.selectedId
-    }
-    void chat.getResponse(messageBody);
-  }
+
   return (
     <div className={ styles.root } key={suggestionDivID}>
-      <Card className={styles.card} data-testid="chatSuggestionItem" onClick={onSendSuggestion} key={cardId}>
+      <Card className={styles.card} data-testid="chatSuggestionItem" onClick={() => { onClick(suggestionMainText) } } key={cardId}>
         <CardHeader header={<Text weight="semibold">{suggestionMainText}</Text>}/>
       </Card>
     </div>

--- a/webapp/src/components/chat/suggestions/ChatSuggestionList.tsx
+++ b/webapp/src/components/chat/suggestions/ChatSuggestionList.tsx
@@ -1,0 +1,27 @@
+import { makeStyles } from "@fluentui/react-components";
+import React from "react";
+import { useAppSelector } from "../../../redux/app/hooks";
+import { RootState } from "../../../redux/app/store";
+import { ChatSuggestion } from "./ChatSuggestion";
+
+const useClasses = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'row',
+    width: '100%',
+    maxWidth: '105em',
+    justifyContent: 'center'
+  }
+});
+
+export const ChatSuggestionList: React.FC = () => {
+  const conversation = useAppSelector((state: RootState) => state.conversations);
+  const classes = useClasses();
+  return (
+    <div className={classes.root}>
+      {
+        conversation.conversations[conversation.selectedId].suggestions.current.map((suggestion, idx) => <ChatSuggestion key={`suggestions-${idx}`} suggestionTitleText={"Suggestion"} suggestionMainText={suggestion} />)
+      }
+    </div>
+  )
+}

--- a/webapp/src/components/chat/suggestions/ChatSuggestionList.tsx
+++ b/webapp/src/components/chat/suggestions/ChatSuggestionList.tsx
@@ -14,13 +14,17 @@ const useClasses = makeStyles({
   }
 });
 
-export const ChatSuggestionList: React.FC = () => {
+interface ChatSuggestionListProps {
+  onClickSuggestion: (message: string) => void;
+}
+
+export const ChatSuggestionList: React.FC<ChatSuggestionListProps> = ({ onClickSuggestion }: ChatSuggestionListProps) => {
   const conversation = useAppSelector((state: RootState) => state.conversations);
   const classes = useClasses();
   return (
     <div className={classes.root}>
       {
-        conversation.conversations[conversation.selectedId].suggestions.current.map((suggestion, idx) => <ChatSuggestion key={`suggestions-${idx}`} suggestionTitleText={"Suggestion"} suggestionMainText={suggestion} />)
+        conversation.conversations[conversation.selectedId].suggestions.current.map((suggestion, idx) => <ChatSuggestion onClick={onClickSuggestion} key={`suggestions-${idx}`} suggestionMainText={suggestion} />)
       }
     </div>
   )

--- a/webapp/src/components/specialization/SpecializationCard.tsx
+++ b/webapp/src/components/specialization/SpecializationCard.tsx
@@ -15,11 +15,12 @@ import { useChat } from '../../libs/hooks';
 import { ISpecialization } from '../../libs/models/Specialization';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
+import { setChatSpecialization } from '../../redux/features/admin/adminSlice';
 import {
     editConversationSpecialization,
     editConversationSystemDescription,
+    updateSuggestions,
 } from '../../redux/features/conversations/conversationsSlice';
-import { setChatSpecialization } from '../../redux/features/admin/adminSlice';
 
 const useStyles = makeStyles({
     main: {
@@ -97,6 +98,9 @@ export const SpecializationCard: React.FC<SpecializationItemProps> = ({ speciali
                     newSystemDescription: specialization.roleInformation,
                 }),
             );
+        });
+        void chat.getSuggestions({ chatId: selectedId }).then((response) => {
+            dispatch(updateSuggestions({ id: selectedId, chatSuggestionMessage: response }))
         });
     };
 

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -109,7 +109,7 @@ export const useChat = () => {
 
     const getSuggestions = async ({ chatId }: { chatId: string}) => {
         const ask = {
-            input: `Make 4 suggestions for topics we could talk about and phrase them as one sentence long questions. Format them as a JSON array. Respond with nothing but a valid JSON object, do not include backticks or a leading json in your response.`,
+            input: `Make 4 suggestions for topics we could talk about and phrase them as one sentence long questions. Format them as a JSON array of strings.`,
             variables: [
                 {
                     key: 'chatId',
@@ -128,7 +128,7 @@ export const useChat = () => {
              ]
         }
         return chatService
-            .getBotResponseAsync(
+            .getBotResponseSilentAsync(
                 ask,
                 await AuthHelper.getSKaaSAccessToken(instance, inProgress),
                 getEnabledPlugins(),

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -95,6 +95,7 @@ export const useChat = () => {
                         disabled: false,
                         hidden: false,
                         specializationId,
+                        suggestions: { ids: [], current: [] }
                     };
 
                     dispatch(addConversation(newChat));
@@ -105,6 +106,37 @@ export const useChat = () => {
             dispatch(addAlert({ message: errorMessage, type: AlertType.Error }));
         }
     };
+
+    const getSuggestions = async ({ chatId }: { chatId: string}) => {
+        const ask = {
+            input: `Make 4 suggestions for topics we could talk about and phrase them as one sentence long questions. Format them as a JSON array. Respond with nothing but a valid JSON object, do not include backticks or a leading json in your response.`,
+            variables: [
+                {
+                    key: 'chatId',
+                    value: chatId,
+                },
+                {
+                    key: 'messageType',
+                    value: ChatMessageType.Message.toString(),
+                },
+                {
+                    key: 'specialization',
+                    value: conversations[chatId].specializationId
+                        ? conversations[chatId].specializationId
+                        : defaultSpecializationId,
+                 }
+             ]
+        }
+        return chatService
+            .getBotResponseAsync(
+                ask,
+                await AuthHelper.getSKaaSAccessToken(instance, inProgress),
+                getEnabledPlugins(),
+            )
+            .catch((e: any) => {
+                throw e;
+            });
+    }
 
     const getResponse = async ({ messageType, value, chatId, kernelArguments, processPlan }: GetResponseOptions) => {
         /* eslint-disable
@@ -233,6 +265,7 @@ export const useChat = () => {
                         disabled: false,
                         hidden: !features[FeatureKeys.MultiUserChat].enabled && chatUsers.length > 1,
                         specializationId: chatSession.specializationId,
+                        suggestions: { ids: [], current: [] }
                     };
                 }
 
@@ -291,6 +324,7 @@ export const useChat = () => {
                     disabled: false,
                     hidden: false,
                     specializationId: chatSession.specializationId,
+                    suggestions: { ids: [], current: [] }
                 };
 
                 dispatch(addConversation(newChat));
@@ -410,6 +444,7 @@ export const useChat = () => {
                     disabled: false,
                     hidden: false,
                     specializationId: result.specializationId,
+                    suggestions: { ids: [], current: [] }
                 };
 
                 dispatch(addConversation(newChat));
@@ -520,6 +555,7 @@ export const useChat = () => {
         createChat,
         loadChats,
         getResponse,
+        getSuggestions,
         downloadBot,
         uploadBot,
         getChatMemorySources,

--- a/webapp/src/libs/semantic-kernel/model/AskResult.ts
+++ b/webapp/src/libs/semantic-kernel/model/AskResult.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { IChatMessage } from '../../models/ChatMessage';
+//import { IChatMessage } from '../../models/ChatMessage';
 import { ISearchValue } from '../../models/SearchResponse';
 
 export interface IAskResult {
-    message: IChatMessage;
+    value: string;
     variables: ContextVariable[];
 }
 

--- a/webapp/src/libs/services/ChatService.ts
+++ b/webapp/src/libs/services/ChatService.ts
@@ -236,7 +236,7 @@ export class ChatService extends BaseService {
 
         const result = await this.getResponseAsync<IAskResult>(
             {
-                commandPath: `chats/${chatId}/messages/silent`,
+                commandPath: `chats/${chatId}/messages?silent=true`,
                 method: 'POST',
                 body: ask,
             },

--- a/webapp/src/libs/services/ChatService.ts
+++ b/webapp/src/libs/services/ChatService.ts
@@ -226,6 +226,27 @@ export class ChatService extends BaseService {
         return result;
     };
 
+    public getBotResponseSilentAsync = async (
+        ask: IAsk,
+        accessToken: string,
+        enabledPlugins?: Plugin[],
+    ): Promise<IAskResult> => {
+        // If function requires any additional api properties, append to context
+        const chatId = ask.variables?.find((variable) => variable.key === 'chatId')?.value as string;
+
+        const result = await this.getResponseAsync<IAskResult>(
+            {
+                commandPath: `chats/${chatId}/messages/silent`,
+                method: 'POST',
+                body: ask,
+            },
+            accessToken,
+            enabledPlugins,
+        );
+
+        return result;
+    };
+
     public joinChatAsync = async (chatId: string, accessToken: string): Promise<IChatSession> => {
         await this.getResponseAsync<any>(
             {

--- a/webapp/src/redux/features/conversations/ChatState.ts
+++ b/webapp/src/redux/features/conversations/ChatState.ts
@@ -22,4 +22,8 @@ export interface ChatState {
     disabled: boolean; // For labeling a chat has been deleted
     hidden: boolean; // For hiding a chat from the list
     specializationId?: string;
+    suggestions: {
+        current: string[];
+        ids: string[];
+    };
 }

--- a/webapp/src/redux/features/conversations/ConversationsState.ts
+++ b/webapp/src/redux/features/conversations/ConversationsState.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { IChatMessage } from '../../../libs/models/ChatMessage';
+import { IAskResult } from '../../../libs/semantic-kernel/model/AskResult';
 import { ChatState } from './ChatState';
 
 export type Conversations = Record<string, ChatState>;
@@ -44,4 +45,9 @@ export interface UpdatePluginStatePayload {
 export interface ConversationSpecializationChange {
     id: string;
     specializationId: string;
+}
+
+export interface ConversationSuggestionsChange {
+    id: string;
+    chatSuggestionMessage: IAskResult;
 }

--- a/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -255,6 +255,25 @@ const setConversationSuggestions = (state: ConversationsState, chatId: string, c
     } catch (e) {
         console.log(`Failed to parse valid JSON array from chat response. ${JSON.stringify(chatMessage, null, 2)}`);
     }
+    try {
+        const response = chatMessage.variables.find((a) => a.key === 'input');
+        if (!response) {
+            throw Error(`No response key.`)
+        }
+        const regex = /```json\s*(\[[\s\S]*?\])\s*```/g;
+        const match = regex.exec(response.value);
+         if (!match) {
+            throw Error(`No regex match.`)
+        }
+        const parsed: any = JSON.parse(match[1]) as unknown;
+        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+            arraySuggestions = parsed;
+        } else {
+            console.log(`Parsed content is not a valid array of strings.`);
+        }
+    } catch (e) {
+        console.log(`Failed to parse valid JSON array from chat response. ${JSON.stringify(chatMessage, null, 2)}`);
+    }
     conversation.suggestions = {
         current: arraySuggestions,
         ids: [] //chatMessage.id != null ? conversation.suggestions.ids.concat(chatMessage.id) : conversation.suggestions.ids


### PR DESCRIPTION
### Motivation and Context

When starting a chat, users may not be aware of what kinds of questions the AI might be able to answer. It would be great to provide them with a few different prompts to choose from, which would ideally be informed by the current chat's context / specialization. 

### Description

This modifies the ChatController's POST endpoint to take a "silent" boolean query param. It defaults to false. When set to true, the backend services will query the chatbot without streaming in the response or adding the exchange to the current conversation history.

I have also refactored some of the existing code for asking the chatbot to avoid major code duplication between these slightly different features.

The frontend has card components that appear when the chatbot responds through the POST request, and when you click one it will send a message on your behalf then make all four disappear. 

### Limitations

It can take a few seconds for the suggestions to pop up after selecting the specialization.

The suggestions do not appear to be informed by the specialization, but this appears to be an issue unrelated to these changes.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
