### PR TITLE
Bugfix - specialization index not being selected when chatting with bot

### DIFF
--- a/webapp/src/libs/services/SpecializationService.ts
+++ b/webapp/src/libs/services/SpecializationService.ts
@@ -56,6 +56,7 @@ export class SpecializationService extends BaseService {
         formData.append('name', body.name);
         formData.append('description', body.description);
         formData.append('roleInformation', body.roleInformation);
+        formData.append('indexName', body.indexName);
         formData.append('deployment', body.deployment);
         // This will need to be parsed on the backend
         formData.append('groupMemberships', body.groupMemberships.join(','));
@@ -101,6 +102,7 @@ export class SpecializationService extends BaseService {
         formData.append('label', body.label);
         formData.append('name', body.name);
         formData.append('description', body.description);
+        formData.append('indexName', body.indexName);
         formData.append('roleInformation', body.roleInformation);
         formData.append('deployment', body.deployment);
         // This will need to be parsed on the backend


### PR DESCRIPTION
### Description

Bugfix - specialization index not being selected when chatting with bot.
The IndexName parameter was not being stored when saving a specialization in Admin tool.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
