### PR TITLE
Disable error type Alert components in prod

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -5,6 +5,11 @@ image:
 # webapp specific values
 ###############
 
+fe:
+  env:
+    - name: "REACT_APP_ENVIRONMENT"
+      value: "development"
+
 webapp:
   image:
     tag: "dev"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -18,6 +18,8 @@ fe:
   env:
     - name: "REACT_APP_BACKEND_URI"
       value: "https://q-pilot.api.pegasus.quartechlab.com/"
+    - name: "REACT_APP_ENVIRONMENT"
+      value: "production"
 
 ###############
 # BE Common values

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -18,6 +18,8 @@ fe:
   env:
     - name: "REACT_APP_BACKEND_URI"
       value: "https://q-pilot-test.api.pegasus.quartechlab.com/"
+    - name: "REACT_APP_ENVIRONMENT"
+      value: "test"
 
 ###############
 # BE Common values

--- a/webapp/.env
+++ b/webapp/.env
@@ -2,3 +2,4 @@
 
 # Required Variables
 REACT_APP_BACKEND_URI=https://localhost:40443/
+REACT_APP_ENVIRONMENT=development

--- a/webapp/src/components/shared/Alerts.tsx
+++ b/webapp/src/components/shared/Alerts.tsx
@@ -3,6 +3,8 @@
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Alert } from '@fluentui/react-components/unstable';
 import React from 'react';
+import { AlertType } from '../../libs/models/AlertType';
+import { Environment } from '../../libs/services/BaseService';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 import { removeAlert } from '../../redux/features/app/appSlice';
@@ -33,32 +35,34 @@ export const Alerts: React.FC = () => {
 
     return (
         <div>
-            {alerts.map(({ type, message, onRetry }, index) => {
-                return (
-                    <Alert
-                        intent={type}
-                        action={{
-                            children: (
-                                <div className={classes.actionItems}>
-                                    {onRetry && <div onClick={onRetry}>Retry</div>}
-                                    <Dismiss16
-                                        aria-label="dismiss message"
-                                        onClick={() => {
-                                            dispatch(removeAlert(index));
-                                        }}
-                                        color="black"
-                                        className={classes.button}
-                                    />
-                                </div>
-                            ),
-                        }}
-                        key={`${index}-${type}`}
-                        className={classes.alert}
-                    >
-                        {message.slice(0, 1000) + (message.length > 1000 ? '...' : '')}
-                    </Alert>
-                );
-            })}
+            {alerts
+                .filter((a) => a.type !== AlertType.Error || Environment !== 'production') //Error messages should not be shown while in production.
+                .map(({ type, message, onRetry }, index) => {
+                    return (
+                        <Alert
+                            intent={type}
+                            action={{
+                                children: (
+                                    <div className={classes.actionItems}>
+                                        {onRetry && <div onClick={onRetry}>Retry</div>}
+                                        <Dismiss16
+                                            aria-label="dismiss message"
+                                            onClick={() => {
+                                                dispatch(removeAlert(index));
+                                            }}
+                                            color="black"
+                                            className={classes.button}
+                                        />
+                                    </div>
+                                ),
+                            }}
+                            key={`${index}-${type}`}
+                            className={classes.alert}
+                        >
+                            {message.slice(0, 1000) + (message.length > 1000 ? '...' : '')}
+                        </Alert>
+                    );
+                })}
         </div>
     );
 };

--- a/webapp/src/libs/models/Global.ts
+++ b/webapp/src/libs/models/Global.ts
@@ -9,4 +9,5 @@ declare global {
 interface ENVType {
     // Add New Runtime Variables here
     REACT_APP_BACKEND_URI: string;
+    REACT_APP_ENVIRONMENT: string;
 }

--- a/webapp/src/libs/services/BaseService.ts
+++ b/webapp/src/libs/services/BaseService.ts
@@ -14,6 +14,8 @@ const noResponseBodyStatusCodes = [202, 204];
 
 export const BackendServiceUrl =
     window._env_.REACT_APP_BACKEND_URI.trim() === '' ? window.origin : window._env_.REACT_APP_BACKEND_URI;
+export const Environment =
+    window._env_.REACT_APP_ENVIRONMENT.trim() === '' ? 'development' : window._env_.REACT_APP_ENVIRONMENT;
 export const NetworkErrorMessage = '\n\nPlease check that your backend is running and that it is accessible by the app';
 
 export class BaseService {


### PR DESCRIPTION

### Motivation and Context

Dean does not wish to see these error messages in the production environment. However, they should still be displayed when using the app in live dev or live test.

### Description

Introduced REACT_APP_ENVIRONMENT var to inform app of the current environment, Alerts component will use this to filter out errors when the environment is set to production.

Wasn't sure if it's necessary to include this in both .env and the dev helm. Also please inform whether "development" is a sensible fallback string in `BaseService.ts`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
