### PR TITLE
Azure Vision as custom OCR engine

### DIFF
--- a/helm/config/dev/appsettings.json
+++ b/helm/config/dev/appsettings.json
@@ -180,8 +180,8 @@
       "EmbeddingGeneratorTypes": ["AzureOpenAIEmbedding"],
       // Vectors can be written to multiple storages, e.g. for data migration, A/B testing, etc.
       "MemoryDbTypes": ["SimpleVectorDb"],
-      // ImageOcrType is the image OCR configuration: "None", "AzureAIDocIntel" or "Tesseract"
-      "ImageOcrType": "None"
+      // ImageOcrType is the image OCR configuration: "None", "AzureAIDocIntel", "AzureVision", or "Tesseract"
+      "ImageOcrType": "AzureVision"
     },
     //
     // Memory retrieval configuration - A single EmbeddingGenerator and VectorDb.
@@ -350,6 +350,14 @@
       "Tesseract": {
         "Language": "eng",
         "FilePath": "./data"
+      },
+
+      // Azure Vision configuration for memory pipeline OCR and general image recognition.
+      // - Endpoint is the endpoint defined in the Azure Vision resource.
+      // - APIKey is the key generated to access this service.
+      "AzureVision" : {
+        "Endpoint": "",
+        "Key" : ""
       }
     }
   },

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -312,6 +312,17 @@ webapi:
         secretKeyRef:
           name: q-pilot-webapi-secret
           key: QAzureOpenAIChatConfig-BlobStorage-ConnectionString
+    - name: "KernelMemory__Services__AzureVision__Key"
+      valueFrom:
+        secretKeyRef:
+          name: q-pilot-webapi-secret
+          key: KernelMemory-Services-AzureVision-Key
+    - name: "KernelMemory__Services__AzureVision__Endpoint"
+      valueFrom:
+        secretKeyRef:
+          name: q-pilot-webapi-secret
+          key: KernelMemory-Services-AzureVision-Endpoint
+
     - name: "APP_NAME"
       value: "webapi"
 

--- a/shared/CopilotChatShared.csproj
+++ b/shared/CopilotChatShared.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.AI.Vision.ImageAnalysis" Version="1.0.0-beta.3" />
     <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.70.240803.1" />
     <PackageReference Include="Microsoft.KernelMemory.MemoryDb.Postgres" Version="0.70.240803.1" />
     <PackageReference Include="Microsoft.KernelMemory.MemoryDb.Redis" Version="0.70.240803.1" />

--- a/shared/Ocr/AzureVision/AzureVisionOcrEngine.cs
+++ b/shared/Ocr/AzureVision/AzureVisionOcrEngine.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.AI.Vision.ImageAnalysis;
+using Microsoft.KernelMemory.DataFormats;
+
+namespace CopilotChat.Shared.Ocr.AzureVision;
+
+/// <summary>
+/// Wrapper for the TesseractEngine within the Tesseract OCR library.
+/// </summary>
+public class AzureVisionOcrEngine : IOcrEngine
+{
+    private readonly ImageAnalysisClient _engine;
+
+    /// <summary>
+    /// Creates a new instance of the TesseractEngineWrapper passing in a valid TesseractEngine.
+    /// </summary>
+    public AzureVisionOcrEngine(AzureVisionOptions azureVisionOptions)
+    {
+        if (string.IsNullOrEmpty(azureVisionOptions.Endpoint) || string.IsNullOrEmpty(azureVisionOptions.Key))
+        {
+            throw new ArgumentNullException($"Missing configuration when constructing {nameof(AzureVisionOcrEngine)}");
+        }
+        this._engine = new ImageAnalysisClient(new System.Uri(azureVisionOptions.Endpoint), new Azure.AzureKeyCredential(azureVisionOptions.Key));
+    }
+
+    ///<inheritdoc/>
+    public async Task<string> ExtractTextFromImageAsync(Stream imageContent, CancellationToken cancellationToken = default)
+    {
+        await using (var imgStream = new MemoryStream())
+        {
+            await imageContent.CopyToAsync(imgStream);
+            imgStream.Position = 0;
+
+            var img = imgStream.ToArray();
+
+            var result = await this._engine.AnalyzeAsync(new System.BinaryData(img), VisualFeatures.DenseCaptions | VisualFeatures.Read);
+            var sb = new StringBuilder();
+            var firstCaption = result.Value.DenseCaptions.Values.First();
+            sb.AppendLine($"The summary of this image's conent is the following: {firstCaption.Text}");
+            sb.AppendLine($"This image contains the following details, when asked to describe you may omit details that duplicate the summary: ");
+            foreach (var caption in result.Value.DenseCaptions.Values.Skip(1))
+            {
+                sb.AppendLine(caption.Text);
+            }
+            if (result.Value.Read.Blocks.Count > 0)
+            {
+                sb.AppendLine($"The following text elements are included in the image: ");
+                foreach (var block in result.Value.Read.Blocks)
+                {
+                    foreach (var line in block.Lines)
+                    {
+                        sb.AppendLine($"{line.Text}");
+                    }
+
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/shared/Ocr/AzureVision/AzureVisionOcrEngine.cs
+++ b/shared/Ocr/AzureVision/AzureVisionOcrEngine.cs
@@ -42,12 +42,15 @@ public class AzureVisionOcrEngine : IOcrEngine
 
             var result = await this._engine.AnalyzeAsync(new System.BinaryData(img), VisualFeatures.DenseCaptions | VisualFeatures.Read);
             var sb = new StringBuilder();
-            var firstCaption = result.Value.DenseCaptions.Values.First();
-            sb.AppendLine($"The summary of this image's conent is the following: {firstCaption.Text}");
-            sb.AppendLine($"This image contains the following details, when asked to describe you may omit details that duplicate the summary: ");
-            foreach (var caption in result.Value.DenseCaptions.Values.Skip(1))
+            if (result.Value.DenseCaptions.Values.Count > 0)
             {
-                sb.AppendLine(caption.Text);
+                var firstCaption = result.Value.DenseCaptions.Values.First();
+                sb.AppendLine($"The summary of this image's content is the following: {firstCaption.Text}");
+                sb.AppendLine($"These details are present in the image. If they are also present in the summary, do not describe them: ");
+                foreach (var caption in result.Value.DenseCaptions.Values.Skip(1))
+                {
+                    sb.AppendLine(caption.Text);
+                }
             }
             if (result.Value.Read.Blocks.Count > 0)
             {

--- a/shared/Ocr/AzureVision/AzureVisionOptions.cs
+++ b/shared/Ocr/AzureVision/AzureVisionOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+namespace CopilotChat.Shared.Ocr.AzureVision;
+
+public sealed class AzureVisionOptions
+{
+    public const string SectionName = "AzureVision";
+
+    [Required]
+    public string? Endpoint { get; set; } = string.Empty;
+    [Required]
+    public string? Key { get; set; } = string.Empty;
+}

--- a/shared/Ocr/ConfigurationExtensions.cs
+++ b/shared/Ocr/ConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
+using CopilotChat.Shared.Ocr.AzureVision;
 using CopilotChat.Shared.Ocr.Tesseract;
 using Microsoft.Extensions.Configuration;
 using Microsoft.KernelMemory.DataFormats;
@@ -31,6 +32,16 @@ public static class ConfigurationExtensions
                 }
 
                 return new TesseractOcrEngine(tesseractOptions);
+
+            case string x when x.Equals(AzureVisionOptions.SectionName, StringComparison.OrdinalIgnoreCase):
+                var azureOptions = configuration
+                       .GetSection($"{MemoryConfiguration.KernelMemorySection}:{MemoryConfiguration.ServicesSection}:{AzureVisionOptions.SectionName}")
+                       .Get<AzureVisionOptions>();
+                if (azureOptions == null)
+                {
+                    throw new ArgumentNullException($"Missing configuration for {ConfigOcrType}: {ocrType}");
+                }
+                return new AzureVisionOcrEngine(azureOptions);
 
             default: // Allow for fall-through for standard OCR settings
                 break;


### PR DESCRIPTION


### Motivation and Context

The Tesseract OCR engine is only really meant to extract text from documents. We should see if it's possible to have a more generalized solution that allows the bot to describe more abstract image features.

### Description

Implemented the IOcrEngine interface using the Azure Vision package. It will attempt to summarize the general idea of the image in addition to specific textual elements. Obviously this is more than just OCR, so perhaps not fully appropriate to take the place of an OCR engine, but this was the easiest way to implement this idea.
This option can now be configured to replace Tesseract using the appsettings. You must set the following to enable it:

* KernelMemory.DataIngestion.ImageOcrType = AzureVision
* KernelMemory.Services.AzureVision.Key = *retrieved from resource*
* KernelMemory.Services.AzureVision.Endpoint = https://qpilot-computer-vision.cognitiveservices.azure.com/

The name of the resource is `qpilot-computer-vision` and is under group `rg-ncus-qsl-openai`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
