### PR TITLE
Fix code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,54 +1,55 @@
 {
-    "prettier.enable": true,
-    "editor.formatOnType": true,
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
-    "[csharp]": {
-      "editor.defaultFormatter": "ms-dotnettools.csharp",
-      "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit"
-      }
-    },
-    "editor.bracketPairColorization.enabled": true,
-    "editor.guides.bracketPairs": "active",
-    "javascript.updateImportsOnFileMove.enabled": "always",
-    "search.exclude": {
-      "**/node_modules": true,
-      "**/build": true
-    },
-    "[typescript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-      "editor.codeActionsOnSave": {
-        "source.organizeImports": "explicit",
-        "source.fixAll": "explicit"
-      }
-    },
-    "[typescriptreact]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-      "editor.codeActionsOnSave": {
-        "source.organizeImports": "explicit",
-        "source.fixAll": "explicit"
-      }
-    },
-    "typescript.updateImportsOnFileMove.enabled": "always",
-    "eslint.enable": true,
-    "eslint.lintTask.enable": true,
-    "eslint.workingDirectories": [
-      {
-        "mode": "auto"
-      }
-    ],
-    "files.associations": {
-      "*.json": "jsonc"
-    },
-    "files.exclude": {
-      "**/.git": true,
-      "**/.hg": true,
-      "**/CVS": true,
-      "**/.DS_Store": true,
-      "**/Thumbs.db": true,
-      "**.lock": true,
-    },
-    "dotnet.defaultSolution": "CopilotChat.sln",
-    "editor.tabSize": 2,
-  }
+  "prettier.enable": true,
+  "editor.formatOnType": true,
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "[csharp]": {
+    "editor.defaultFormatter": "ms-dotnettools.csharp",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  },
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active",
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/build": true
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
+    }
+  },
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  "eslint.enable": true,
+  "eslint.lintTask.enable": true,
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+  "files.associations": {
+    "*.json": "jsonc"
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
+    "**.lock": true
+  },
+  "dotnet.defaultSolution": "CopilotChat.sln",
+  "editor.tabSize": 2,
+  "editor.defaultFormatter": "csharpier.csharpier-vscode"
+}

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -17,6 +17,7 @@ using CopilotChat.WebApi.Plugins.Chat.Ext;
 using CopilotChat.WebApi.Plugins.Utils;
 using CopilotChat.WebApi.Services;
 using CopilotChat.WebApi.Storage;
+using CopilotChat.WebApi.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -144,10 +145,7 @@ public class ChatHistoryController : ControllerBase
         // Add the user to the chat session
         await this._participantRepository.CreateAsync(new ChatParticipant(this._authInfo.UserId, newChat.Id));
 
-        var sanitizedChatId = newChat
-            .Id.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase)
-            .Replace("\n", "", StringComparison.InvariantCultureIgnoreCase)
-            .Replace("\r", "", StringComparison.InvariantCultureIgnoreCase);
+        var sanitizedChatId = RequestUtils.GetSanitizedParameter(newChat.Id);
         this._logger.LogDebug("Created chat session with id {0}.", sanitizedChatId);
 
         return this.CreatedAtRoute(

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -144,7 +144,7 @@ public class ChatHistoryController : ControllerBase
         // Add the user to the chat session
         await this._participantRepository.CreateAsync(new ChatParticipant(this._authInfo.UserId, newChat.Id));
 
-        var sanitizedChatId = newChat.Id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        var sanitizedChatId = newChat.Id.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase).Replace("\n", "", StringComparison.InvariantCultureIgnoreCase).Replace("\r", "", StringComparison.InvariantCultureIgnoreCase);
         this._logger.LogDebug("Created chat session with id {0}.", sanitizedChatId);
 
         return this.CreatedAtRoute(

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -144,7 +144,8 @@ public class ChatHistoryController : ControllerBase
         // Add the user to the chat session
         await this._participantRepository.CreateAsync(new ChatParticipant(this._authInfo.UserId, newChat.Id));
 
-        this._logger.LogDebug("Created chat session with id {0}.", newChat.Id);
+        var sanitizedChatId = newChat.Id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        this._logger.LogDebug("Created chat session with id {0}.", sanitizedChatId);
 
         return this.CreatedAtRoute(
             GetChatRoute,

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -144,7 +144,10 @@ public class ChatHistoryController : ControllerBase
         // Add the user to the chat session
         await this._participantRepository.CreateAsync(new ChatParticipant(this._authInfo.UserId, newChat.Id));
 
-        var sanitizedChatId = newChat.Id.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase).Replace("\n", "", StringComparison.InvariantCultureIgnoreCase).Replace("\r", "", StringComparison.InvariantCultureIgnoreCase);
+        var sanitizedChatId = newChat
+            .Id.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase)
+            .Replace("\n", "", StringComparison.InvariantCultureIgnoreCase)
+            .Replace("\r", "", StringComparison.InvariantCultureIgnoreCase);
         this._logger.LogDebug("Created chat session with id {0}.", sanitizedChatId);
 
         return this.CreatedAtRoute(


### PR DESCRIPTION
Fixes [https://github.com/Quartech/chat-copilot/security/code-scanning/1](https://github.com/Quartech/chat-copilot/security/code-scanning/1)

To fix the problem, we need to sanitize the `Id` before logging it. Since the log entries are plain text, we should remove any new line characters from the `Id` to prevent log forging. This can be done using the `String.Replace` method to replace new line characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
