### PR TITLE
Default Quartech Images for specializations not found

### DIFF
--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -99,6 +99,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="wwwroot\Quartech_Icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="wwwroot\Quartech_Logo_RGB.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+  <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 </Project>

--- a/webapi/Utilities/ResourceUtils.cs
+++ b/webapi/Utilities/ResourceUtils.cs
@@ -21,15 +21,22 @@ internal static class ResourceUtils
 
         if (!File.Exists(imageFilePath))
         {
-            throw new FileNotFoundException(
-                $"The image '{imageFileName}' was not found in the wwwroot directory.",
-                imageFileName
-            );
+            Console.WriteLine($"The image '{imageFileName}' was not found in the wwwroot directory.");
+            return string.Empty;
         }
 
-        byte[] imageBytes = File.ReadAllBytes(imageFilePath);
-        string base64ImageRepresentation = Convert.ToBase64String(imageBytes);
-
-        return $"data:image/png;base64,{base64ImageRepresentation}";
+        try
+        {
+            byte[] imageBytes = File.ReadAllBytes(imageFilePath);
+            string base64ImageRepresentation = Convert.ToBase64String(imageBytes);
+            return $"data:image/png;base64,{base64ImageRepresentation}";
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"An unexpected error occurred while processing the image '{imageFileName}'",
+                ex
+            );
+        }
     }
 }


### PR DESCRIPTION
### Description

Default Quartech static images are not being built and deployed in the dev environment. Updated the .csproj to specifically include them in the build. Also updated ResourceUtils.GetImageAsDataUri() to no longer throw an exception if the images are missing.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
