### PR TITLE
Default static Quartech images not found in deployed environments

### DIFF
--- a/docker/webapi/Dockerfile
+++ b/docker/webapi/Dockerfile
@@ -8,7 +8,6 @@ RUN dotnet dev-certs https
 # copy everything else and build app
 COPY webapi webapi
 COPY shared shared
-COPY wwwroot wwwroot
 RUN cd webapi && \
   dotnet restore --use-current-runtime && \
   apt update && apt install -y wget && \
@@ -20,7 +19,6 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0
 ENV Kestrel__Endpoints__Http__Url=http://0.0.0.0:8080
 WORKDIR /app
 COPY --from=builder /app .
-COPY wwwroot wwwroot
 COPY --from=builder /root/.dotnet/corefx/cryptography/x509stores/my/* /root/.dotnet/corefx/cryptography/x509stores/my/
 RUN apt update && \
   apt install -y libleptonica-dev libtesseract-dev libc6-dev libjpeg62-turbo-dev libgdiplus && \

--- a/docker/webapi/Dockerfile
+++ b/docker/webapi/Dockerfile
@@ -8,6 +8,7 @@ RUN dotnet dev-certs https
 # copy everything else and build app
 COPY webapi webapi
 COPY shared shared
+COPY wwwroot wwwroot
 RUN cd webapi && \
   dotnet restore --use-current-runtime && \
   apt update && apt install -y wget && \
@@ -19,6 +20,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0
 ENV Kestrel__Endpoints__Http__Url=http://0.0.0.0:8080
 WORKDIR /app
 COPY --from=builder /app .
+COPY wwwroot wwwroot
 COPY --from=builder /root/.dotnet/corefx/cryptography/x509stores/my/* /root/.dotnet/corefx/cryptography/x509stores/my/
 RUN apt update && \
   apt install -y libleptonica-dev libtesseract-dev libc6-dev libjpeg62-turbo-dev libgdiplus && \

--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -100,10 +100,10 @@
 
   <ItemGroup>
     <Content Update="wwwroot\Quartech_Icon.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
     <Content Update="wwwroot\Quartech_Logo_RGB.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
   


### PR DESCRIPTION
### Description

Static files in wwwroot are missing in deployed environments causing errors when updating Specializations. Updated the .csproj file to use CopyToPublishDirectory since the Dockerfile does not run `dotnet build` prior to publishing. 

Also added some more error handling to the image update specialization workflow.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
