### PR TITLE
Update input buttons inline and size

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -240,11 +240,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                             title="Attach file"
                             aria-label="Attach file button"
                         />
-                        {
-                            chatState.importingDocuments &&
-                            chatState.importingDocuments.length > 0 &&
+                        {chatState.importingDocuments && chatState.importingDocuments.length > 0 && (
                             <Spinner size="tiny" />
-                        }
+                        )}
                     </div>
                 </div>
                 <Textarea

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -45,7 +45,7 @@ const useClasses = makeStyles({
         width: '100%',
     },
     textarea: {
-        maxHeight: '80px',
+        resize: 'none',
     },
     controls: {
         display: 'flex',

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -285,6 +285,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                             chatState.disabled ||
                             (chatState.importingDocuments && chatState.importingDocuments.length > 0)
                         }
+                        size="large"
                         appearance="transparent"
                         icon={<AttachRegular />}
                         onClick={() => documentFileRef.current?.click()}
@@ -296,6 +297,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                 <div className={classes.essentials}>
                     {recognizer && (
                         <Button
+                            size="large"
                             appearance="transparent"
                             disabled={chatState.disabled || isListening}
                             icon={<MicRegular />}
@@ -304,6 +306,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     )}
                     <Button
                         title="Submit"
+                        size="large"
                         aria-label="Submit message"
                         appearance="transparent"
                         icon={<SendRegular />}

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -266,55 +266,55 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                         }
                     }}
                 />
-            </div>
-            <div className={classes.controls}>
-                <div className={classes.functional}>
-                    {/* Hidden input for file upload. Only accept .txt and .pdf files for now. */}
-                    <input
-                        type="file"
-                        ref={documentFileRef}
-                        style={{ display: 'none' }}
-                        accept={Constants.app.importTypes}
-                        multiple={true}
-                        onChange={() => {
-                            void fileHandler.handleImport(selectedId, documentFileRef);
-                        }}
-                    />
-                    <Button
-                        disabled={
-                            chatState.disabled ||
-                            (chatState.importingDocuments && chatState.importingDocuments.length > 0)
-                        }
-                        size="large"
-                        appearance="transparent"
-                        icon={<AttachRegular />}
-                        onClick={() => documentFileRef.current?.click()}
-                        title="Attach file"
-                        aria-label="Attach file button"
-                    />
-                    {chatState.importingDocuments && chatState.importingDocuments.length > 0 && <Spinner size="tiny" />}
-                </div>
-                <div className={classes.essentials}>
-                    {recognizer && (
+                <div className={classes.controls}>
+                    <div className={classes.functional}>
+                        {/* Hidden input for file upload. Only accept .txt and .pdf files for now. */}
+                        <input
+                            type="file"
+                            ref={documentFileRef}
+                            style={{ display: 'none' }}
+                            accept={Constants.app.importTypes}
+                            multiple={true}
+                            onChange={() => {
+                                void fileHandler.handleImport(selectedId, documentFileRef);
+                            }}
+                        />
                         <Button
+                            disabled={
+                                chatState.disabled ||
+                                (chatState.importingDocuments && chatState.importingDocuments.length > 0)
+                            }
                             size="large"
                             appearance="transparent"
-                            disabled={chatState.disabled || isListening}
-                            icon={<MicRegular />}
-                            onClick={handleSpeech}
+                            icon={<AttachRegular />}
+                            onClick={() => documentFileRef.current?.click()}
+                            title="Attach file"
+                            aria-label="Attach file button"
                         />
-                    )}
-                    <Button
-                        title="Submit"
-                        size="large"
-                        aria-label="Submit message"
-                        appearance="transparent"
-                        icon={<SendRegular />}
-                        onClick={() => {
-                            handleSubmit(input);
-                        }}
-                        disabled={chatState.disabled || isSpecializationDisabled()}
-                    />
+                        {chatState.importingDocuments && chatState.importingDocuments.length > 0 && <Spinner size="tiny" />}
+                    </div>
+                    <div className={classes.essentials}>
+                        {recognizer && (
+                            <Button
+                                size="large"
+                                appearance="transparent"
+                                disabled={chatState.disabled || isListening}
+                                icon={<MicRegular />}
+                                onClick={handleSpeech}
+                            />
+                        )}
+                        <Button
+                            title="Submit"
+                            size="large"
+                            aria-label="Submit message"
+                            appearance="transparent"
+                            icon={<SendRegular />}
+                            onClick={() => {
+                                handleSubmit(input);
+                            }}
+                            disabled={chatState.disabled || isSpecializationDisabled()}
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -291,7 +291,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                             title="Attach file"
                             aria-label="Attach file button"
                         />
-                        {chatState.importingDocuments && chatState.importingDocuments.length > 0 && <Spinner size="tiny" />}
+                        {
+                            chatState.importingDocuments &&
+                            chatState.importingDocuments.length > 0 &&
+                            <Spinner size="tiny" />
+                        }
                     </div>
                     <div className={classes.essentials}>
                         {recognizer && (

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -215,6 +215,38 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                 <ChatStatus chatState={chatState} />
             </div>
             <div className={classes.content}>
+                <div className={classes.controls}>
+                    <div className={classes.functional}>
+                        {/* Hidden input for file upload. Only accept .txt and .pdf files for now. */}
+                        <input
+                            type="file"
+                            ref={documentFileRef}
+                            style={{ display: 'none' }}
+                            accept={Constants.app.importTypes}
+                            multiple={true}
+                            onChange={() => {
+                                void fileHandler.handleImport(selectedId, documentFileRef);
+                            }}
+                        />
+                        <Button
+                            disabled={
+                                chatState.disabled ||
+                                (chatState.importingDocuments && chatState.importingDocuments.length > 0)
+                            }
+                            size="large"
+                            appearance="transparent"
+                            icon={<AttachRegular />}
+                            onClick={() => documentFileRef.current?.click()}
+                            title="Attach file"
+                            aria-label="Attach file button"
+                        />
+                        {
+                            chatState.importingDocuments &&
+                            chatState.importingDocuments.length > 0 &&
+                            <Spinner size="tiny" />
+                        }
+                    </div>
+                </div>
                 <Textarea
                     title="Chat input"
                     aria-label="Chat input field. Click enter to submit input."

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -291,11 +291,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                             title="Attach file"
                             aria-label="Attach file button"
                         />
-                        {
-                            chatState.importingDocuments &&
-                            chatState.importingDocuments.length > 0 &&
+                        {chatState.importingDocuments && chatState.importingDocuments.length > 0 && (
                             <Spinner size="tiny" />
-                        }
+                        )}
                     </div>
                     <div className={classes.essentials}>
                         {recognizer && (

--- a/webapp/src/components/search/SearchInput.tsx
+++ b/webapp/src/components/search/SearchInput.tsx
@@ -153,6 +153,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({ onSubmit, defaultSpeci
                         }}
                     /> */}
                     <Button
+                        size="large"
                         title="Submit"
                         aria-label="Search"
                         appearance="transparent"


### PR DESCRIPTION
### Motivation and Context

Updating chat input `Button` elements to create a smoother user experience and give a sleeker look.

There are a few areas that utilize the `SendRegular` icon. Would be good to keep these inline with one another. Is it too much to add a common `SendButton` component?

### Description

- refactor: input `Button` `size` prop set to 'large'
- refactor: `ChatInput` `TextArea` to not allow manual resizing
- refactor: `ChatInput` input buttons to be inline with `TextArea`

## SearchInput
### Previous
![image](https://github.com/user-attachments/assets/c7264d3a-5c08-430a-aeba-e68a3e3e3e05)
### Proposal
![image](https://github.com/user-attachments/assets/86755a4f-a166-4c5f-9264-c16d8d22dd72)

## ChatInput
### Previous
![image](https://github.com/user-attachments/assets/c15c3d0d-a062-4992-bc65-55df9bbe5114)
### Proposal
![image](https://github.com/user-attachments/assets/b85b1cd1-95d7-4903-8151-e911dc121019)

### Contribution Checklist

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
