### PR TITLE
Deleting specialization requires a manual refresh for it to disappear

### DIFF
--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -186,21 +186,24 @@ public class QSpecializationService : IQSpecializationService
 
         await this._specializationSourceRepository.DeleteAsync(specializationToDelete);
 
-        var imageFileUri = new Uri(specializationToDelete.ImageFilePath);
-        var iconFileUri = new Uri(specializationToDelete.IconFilePath);
-
-        // Remove the image file from the blob storage if it is a Blob Storage URI
-        if (await this._qBlobStorage.BlobExistsAsync(imageFileUri))
+        // Attempt to create URIs for image and icon
+        if (
+            Uri.TryCreate(specializationToDelete.ImageFilePath, UriKind.Absolute, out var imageFileUri)
+            && Uri.TryCreate(specializationToDelete.IconFilePath, UriKind.Absolute, out var iconFileUri)
+        )
         {
-            await this._qBlobStorage.DeleteBlobByURIAsync(imageFileUri);
-        }
+            // Delete image file from blob storage if it exists
+            if (await this._qBlobStorage.BlobExistsAsync(imageFileUri))
+            {
+                await this._qBlobStorage.DeleteBlobByURIAsync(imageFileUri);
+            }
 
-        // Remove the icon file from the blob storage if it is a Blob Storage URI
-        if (await this._qBlobStorage.BlobExistsAsync(iconFileUri))
-        {
-            await this._qBlobStorage.DeleteBlobByURIAsync(iconFileUri);
+            // Delete icon file from blob storage if it exists
+            if (await this._qBlobStorage.BlobExistsAsync(iconFileUri))
+            {
+                await this._qBlobStorage.DeleteBlobByURIAsync(iconFileUri);
+            }
         }
-
         return true;
     }
 


### PR DESCRIPTION
### Description

The problem that originally caused this was actually fixed in https://github.com/Quartech/chat-copilot/pull/116. 

The default specialization static images were missing, so the image file paths of a specialization was being saved as empty strings. Then, when we try to delete a specialization, it looks for the image to delete in the blob storage by trying to create a URI with an empty string, so it errors out. Since the static images are now there, it won't break anymore. But regardless, in this PR I added some error handling such that if an image URI does not parse, it will no longer throw.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
