### PR TITLE
Sam/undo doc changes

### DIFF
--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -110,7 +110,7 @@ public class ChatPlugin
         IOptions<QAzureOpenAIChatOptions> qAzureOpenAIChatOptions,
         ILogger logger,
         AzureContentSafety? contentSafety = null,
-        bool isUserIntentExtractionEnabled = false
+        bool isUserIntentExtractionEnabled = true
     ) // Parameter for feature flag
     {
         this._logger = logger;
@@ -432,7 +432,7 @@ public class ChatPlugin
     )
     {
         var memoryQueryTask = this._semanticMemoryRetriever.QueryMemoriesAsync(
-            this._promptOptions.DocumentMemoryName,
+            promptConfig.UserIntent,
             chatId,
             tokenBudget
         );


### PR DESCRIPTION
### Motivation and Context

The motivation behind the PR is to remove the context injection we are doing for document upload so we can fix the bug bot response bug.

### Description

Instead of using context injection, initially in the base code in the prompt config memory text gets added as a system message but this doesn't help us in getting document memory to work with our document in the search indexes. During chat context injection, I was adding document memory as user message in the chat context to make doc upload work. he reason I chose this over the first method in the first place was at the time I noticed the quality of responses was better while injecting the whole context for some reason, even though there was a lot of overlap of fields in the prompt config and chat context. In hindsight, this could be because the intent was disabled. Once I removed the context injection and just added memory text as user message to the prompt config, the do upload is working fine and bug hasn't appeared. But what I also noticed was during memory extraction for responses, the code was using system instructions to filter out irrelevant memories to be used for the response for the current prompt which is not ideal and would result in behavior where even though it has documents with the answers we want, it doesn't have the document content as the relevant memory for the response it is making for the prompt. That's why instead of using the system instructions, it just makes sense to me to use user intent so it is better able to extract the actual relevant memories for the prompt and this change fixes the behavior mentioned above.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
