### PR TITLE
Grey out Admin tab instead of hiding it when a user does not have access

### DIFF
--- a/webapp/src/components/chat/chat-list/ChatType.tsx
+++ b/webapp/src/components/chat/chat-list/ChatType.tsx
@@ -75,11 +75,16 @@ export const ChatType: FC = () => {
                 <Tab data-testid="searchTab" id="search" value="search" aria-label="Search Tab" title="Search Tab">
                     Search - Beta
                 </Tab>
-                {hasAdmin && (
-                    <Tab data-testid="adminTab" id="admin" value="admin" aria-label="admin Tab" title="Admin Tab">
-                        Admin
-                    </Tab>
-                )}
+                <Tab
+                    disabled={!hasAdmin}
+                    data-testid="adminTab"
+                    id="admin"
+                    value="admin"
+                    aria-label="admin Tab"
+                    title="Admin Tab"
+                >
+                    Admin
+                </Tab>
             </TabList>
             {selectedTab === 'chat' && <ChatList />}
             {selectedTab === 'search' && <SearchList />}


### PR DESCRIPTION
### Description
Rather than hiding the Admin menu when the user does not have access it is desired to have it greyed out and disabled. This shows that there are more options available to those that maybe still have to be granted Admin access.
![image](https://github.com/user-attachments/assets/d759134e-459b-4c88-9d0c-fe87921d3239)
### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
