### PR TITLE
feat: create RequestUtils.GetSanitizedParameters

### DIFF
--- a/webapi/Controllers/ChatMemoryController.cs
+++ b/webapi/Controllers/ChatMemoryController.cs
@@ -9,6 +9,7 @@ using CopilotChat.WebApi.Extensions;
 using CopilotChat.WebApi.Models.Request;
 using CopilotChat.WebApi.Options;
 using CopilotChat.WebApi.Storage;
+using CopilotChat.WebApi.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -66,8 +67,8 @@ public class ChatMemoryController : ControllerBase
     {
         // Sanitize the log input by removing new line characters.
         // https://github.com/microsoft/chat-copilot/security/code-scanning/1
-        var sanitizedChatId = GetSanitizedParameter(chatId);
-        var sanitizedMemoryType = GetSanitizedParameter(type);
+        var sanitizedChatId = RequestUtils.GetSanitizedParameter(chatId);
+        var sanitizedMemoryType = RequestUtils.GetSanitizedParameter(type);
 
         // Map the requested memoryType to the memory store container name
         if (!this._promptOptions.TryGetMemoryContainerName(type, out string memoryContainerName))
@@ -116,13 +117,4 @@ public class ChatMemoryController : ControllerBase
 
         return this.Ok(memories);
     }
-
-    #region Private
-
-    private static string GetSanitizedParameter(string parameterValue)
-    {
-        return parameterValue.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
-    }
-
-    # endregion
 }

--- a/webapi/Utilities/RequestUtils.cs
+++ b/webapi/Utilities/RequestUtils.cs
@@ -8,7 +8,7 @@ namespace CopilotChat.WebApi.Utilities;
 internal static class RequestUtils
 {
     /// <summary>
-    /// Remove Environment.NewLine from paramter values.
+    /// Remove Environment.NewLine from parameter values.
     /// </summary>
     /// <param name="parameterValue">String request parameter.</param>
     /// <returns>Parameter string with all Environment.NewLine characters removed.</returns>

--- a/webapi/Utilities/RequestUtils.cs
+++ b/webapi/Utilities/RequestUtils.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace CopilotChat.WebApi.Utilities;
+
+/// <summary>
+/// Utility class for handling request-related operations.
+/// </summary>
+internal static class RequestUtils
+{
+    /// <summary>
+    /// Remove Environment.NewLine from paramter values.
+    /// </summary>
+    /// <param name="parameterValue">String request parameter.</param>
+    /// <returns>Parameter string with all Environment.NewLine characters removed.</returns>
+    public static string GetSanitizedParameter(string parameterValue)
+    {
+        return parameterValue.Replace(Environment.NewLine, string.Empty, StringComparison.Ordinal);
+    }
+}

--- a/webapi/Utilities/RequestUtils.test.cs
+++ b/webapi/Utilities/RequestUtils.test.cs
@@ -9,10 +9,9 @@ public class RequestUtilsTest
     [TestMethod]
     public void GetSanitizedParameter_SanitizeParameterString()
     {
-        var expected = "ca138d45-9785-4ff3-9119-e77c5341ba95";
-        var parameterValue = $"ca138d45{Environment.NewLine}-9785-4ff3-9119-e77c5341ba95{Environment.NewLine}";
+        var expected = "request string parameter";
+        var parameterValue = $"request{Environment.NewLine} string parameter{Environment.NewLine}";
 
         Assert.AreEqual(expected, RequestUtils.GetSanitizedParameter(parameterValue));
     }
 }
-

--- a/webapi/Utilities/RequestUtils.test.cs
+++ b/webapi/Utilities/RequestUtils.test.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CopilotChat.WebApi.Utilities;
+
+[TestClass]
+public class RequestUtilsTest
+{
+    [TestMethod]
+    public void GetSanitizedParameter_SanitizeParameterString()
+    {
+        var expected = "ca138d45-9785-4ff3-9119-e77c5341ba95";
+        var parameterValue = $"ca138d45{Environment.NewLine}-9785-4ff3-9119-e77c5341ba95{Environment.NewLine}";
+
+        Assert.AreEqual(expected, RequestUtils.GetSanitizedParameter(parameterValue));
+    }
+}
+


### PR DESCRIPTION
### Motivation and Context

In response to the proposal to sanitize request parameters by [removing new line characters](https://github.com/Quartech/chat-copilot/pull/111). This logic exists in other parts of the application, we can move this logic to a more central location.

### Description

- feat: Create RequestUtils.GetSanitizedParameters
- refactor: use RequestUtils in place of private methods

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
