### PR TITLE
Chats GET endpoint include title

### DIFF
--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -196,7 +196,12 @@ public class ChatHistoryController : ControllerBase
             ChatSession? chat = null;
             if (await this._sessionRepository.TryFindByIdAsync(chatParticipant.ChatId, callback: v => chat = v))
             {
-                if (Regex.IsMatch(chat!.Title, @"/Q-Pilot @ [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,4}, [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [A,P]M/"))
+                if (
+                    Regex.IsMatch(
+                        chat!.Title,
+                        @"/Q-Pilot @ [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,4}, [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [A,P]M/"
+                    )
+                )
                 {
                     var messagesInThisChat = await this._messageRepository.FindByChatIdAsync(chatParticipant.ChatId);
                     var firstUserMessage = messagesInThisChat.Where(m => m.UserId != "Bot").MinBy(m => m.Timestamp);

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -195,6 +195,12 @@ public class ChatHistoryController : ControllerBase
             ChatSession? chat = null;
             if (await this._sessionRepository.TryFindByIdAsync(chatParticipant.ChatId, callback: v => chat = v))
             {
+                var messagesInThisChat = await this._messageRepository.FindByChatIdAsync(chatParticipant.ChatId);
+                var firstUserMessage = messagesInThisChat.Where(m => m.UserId != "Bot").MinBy(m => m.Timestamp);
+                if (firstUserMessage != null)
+                {
+                    chat!.Title = firstUserMessage.Content;
+                }
                 chats.Add(chat!);
             }
             else

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Auth;
@@ -195,12 +196,16 @@ public class ChatHistoryController : ControllerBase
             ChatSession? chat = null;
             if (await this._sessionRepository.TryFindByIdAsync(chatParticipant.ChatId, callback: v => chat = v))
             {
-                var messagesInThisChat = await this._messageRepository.FindByChatIdAsync(chatParticipant.ChatId);
-                var firstUserMessage = messagesInThisChat.Where(m => m.UserId != "Bot").MinBy(m => m.Timestamp);
-                if (firstUserMessage != null)
+                if (Regex.IsMatch(chat!.Title, @"/Q-Pilot @ [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,4}, [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [A,P]M/"))
                 {
-                    chat!.Title = firstUserMessage.Content;
+                    var messagesInThisChat = await this._messageRepository.FindByChatIdAsync(chatParticipant.ChatId);
+                    var firstUserMessage = messagesInThisChat.Where(m => m.UserId != "Bot").MinBy(m => m.Timestamp);
+                    if (firstUserMessage != null)
+                    {
+                        chat!.Title = firstUserMessage.Content;
+                    }
                 }
+
                 chats.Add(chat!);
             }
             else


### PR DESCRIPTION


### Motivation and Context
The chats are now loaded separately from messages, so the frontend does not have a friendly title to display on chats in the list until you click on them.

### Description
This change makes the GET endpoint for retrieving the list of chats also override the title to the user's first message in the chat whenever available. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
