### PR TITLE
Expand matches in search list

### DIFF
--- a/webapp/src/components/search/SearchInput.tsx
+++ b/webapp/src/components/search/SearchInput.tsx
@@ -6,7 +6,7 @@ import { AlertType } from '../../libs/models/AlertType';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 import { addAlert } from '../../redux/features/app/appSlice';
-import { setSearch } from '../../redux/features/search/searchSlice';
+import { setSearch, setSelectedSearchItem } from '../../redux/features/search/searchSlice';
 
 const useClasses = makeStyles({
     root: {
@@ -75,15 +75,19 @@ export const SearchInput: React.FC<SearchInputProps> = ({ onSubmit, defaultSpeci
         if (value.trim() === '' || specialization.id.trim() === '') {
             return; // only submit if value is not empty
         }
-        onSubmit(specialization.id, value).catch((error) => {
-            const message = `Error submitting search input: ${(error as Error).message}`;
-            dispatch(
-                addAlert({
-                    type: AlertType.Error,
-                    message,
-                }),
-            );
-        });
+        onSubmit(specialization.id, value)
+            .then(() => {
+                dispatch(setSelectedSearchItem({ filename: '', id: 0 }));
+            })
+            .catch((error) => {
+                const message = `Error submitting search input: ${(error as Error).message}`;
+                dispatch(
+                    addAlert({
+                        type: AlertType.Error,
+                        message,
+                    }),
+                );
+            });
         //clearSearchInputState();
     };
 

--- a/webapp/src/components/search/SearchListSection.tsx
+++ b/webapp/src/components/search/SearchListSection.tsx
@@ -3,11 +3,12 @@ import {
     AccordionHeader,
     AccordionItem,
     AccordionPanel,
+    AccordionToggleEventHandler,
     makeStyles,
     shorthands,
     tokens,
 } from '@fluentui/react-components';
-import React, { useId } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 import { SearchValueFormatted } from '../../redux/features/search/SearchState';
@@ -46,10 +47,17 @@ export const SearchListSection: React.FC<ISearchListSectionProps> = ({ value, in
     //const matches = value.matches;
     const entryPoints = value.entryPointList;
     const accordionPanelId = useId();
+    const [openItems, setOpenItems] = useState<string[]>([]);
+    const handleToggle: AccordionToggleEventHandler<string> = (_event, data) => {
+        setOpenItems(data.openItems);
+    };
+    useEffect(() => {
+        setOpenItems([]);
+    }, [entryPoints]);
     //const searchListItemId = useId();
     return entryPoints.length > 0 ? (
         <div className={classes.root}>
-            <Accordion collapsible={true} multiple={true}>
+            <Accordion onToggle={handleToggle} openItems={openItems} collapsible={true} multiple={true}>
                 <AccordionItem value={index}>
                     <AccordionHeader>{value.filename}</AccordionHeader>
                     {entryPoints.map((match, idx) => {

--- a/webapp/src/components/search/SearchListSection.tsx
+++ b/webapp/src/components/search/SearchListSection.tsx
@@ -1,18 +1,18 @@
 import {
+    Accordion,
+    AccordionHeader,
+    AccordionItem,
+    AccordionPanel,
     makeStyles,
     shorthands,
     tokens,
-    Accordion,
-    AccordionItem,
-    AccordionHeader,
-    AccordionPanel,
 } from '@fluentui/react-components';
+import React, { useId } from 'react';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
-import { ISearchValue } from '../../libs/models/SearchResponse';
+import { SearchValueExtended } from '../../redux/features/search/SearchState';
 import { Breakpoints } from '../../styles';
 import { SearchListItem } from './search-list/SearchListItem';
-import React, { useId } from 'react';
 
 const useClasses = makeStyles({
     root: {
@@ -36,29 +36,37 @@ const useClasses = makeStyles({
 });
 
 interface ISearchListSectionProps {
-    value: ISearchValue;
+    value: SearchValueExtended;
     index: number;
 }
 
 export const SearchListSection: React.FC<ISearchListSectionProps> = ({ value, index }) => {
     const classes = useClasses();
     const { selectedSearchItem } = useAppSelector((state: RootState) => state.search);
-    const matches = value.matches;
+    //const matches = value.matches;
+    const entryPoints = value.entryPointList;
     const accordionPanelId = useId();
     //const searchListItemId = useId();
-    return matches.length > 0 ? (
+    return entryPoints.length > 0 ? (
         <div className={classes.root}>
             <Accordion collapsible={true} multiple={true}>
                 <AccordionItem value={index}>
                     <AccordionHeader>{value.filename}</AccordionHeader>
-                    {matches.map((match) => {
-                        const label = match.label;
-                        const id = match.id;
-                        const selectedItem = match.id === selectedSearchItem;
+                    {entryPoints.map((match, idx) => {
+                        const label = match;
+                        const id = idx;
+                        const selectedItem =
+                            selectedSearchItem.id == idx && value.filename == selectedSearchItem.filename;
 
                         return (
-                            <AccordionPanel key={'acc' + accordionPanelId + id}>
-                                <SearchListItem key={id} label={label} id={id} isSelected={selectedItem} />
+                            <AccordionPanel key={'acc' + accordionPanelId + String(id)}>
+                                <SearchListItem
+                                    key={id}
+                                    filename={value.filename}
+                                    label={label}
+                                    id={id}
+                                    isSelected={selectedItem}
+                                />
                             </AccordionPanel>
                         );
                     })}

--- a/webapp/src/components/search/SearchListSection.tsx
+++ b/webapp/src/components/search/SearchListSection.tsx
@@ -10,7 +10,7 @@ import {
 import React, { useId } from 'react';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
-import { SearchValueExtended } from '../../redux/features/search/SearchState';
+import { SearchValueFormatted } from '../../redux/features/search/SearchState';
 import { Breakpoints } from '../../styles';
 import { SearchListItem } from './search-list/SearchListItem';
 
@@ -36,7 +36,7 @@ const useClasses = makeStyles({
 });
 
 interface ISearchListSectionProps {
-    value: SearchValueExtended;
+    value: SearchValueFormatted;
     index: number;
 }
 

--- a/webapp/src/components/search/SearchRoom.tsx
+++ b/webapp/src/components/search/SearchRoom.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSearch } from '../../libs/hooks/useSearch';
 import { ISearchMetaData } from '../../libs/models/SearchResponse';
 import { useAppSelector } from '../../redux/app/hooks';
@@ -48,13 +48,9 @@ export const SearchRoom: React.FC = () => {
     let metaData: ISearchMetaData = {};
 
     values.forEach((data) => {
-        // data.matches.map((match) => {
-        //     if (match.id === selectedSearchItem) {
-        //         displayContent = match.content;
-        //         metaData = match.metadata;
-        //     }
-        // });
         if (data.filename === selectedSearchItem.filename) {
+            //The placeholder tags exist to make it easy to find the currently selected text in the string and highlight it by replacing
+            //the placeholder tag with a mark tag.
             const regex = new RegExp(
                 `<PLACEHOLDER_${selectedSearchItem.id + 1}>(.*?)<\/PLACEHOLDER_${selectedSearchItem.id + 1}>`,
             );
@@ -72,6 +68,16 @@ export const SearchRoom: React.FC = () => {
     const handleSubmit = async (specialization: string, value: string) => {
         await search.getResponse(specialization, value);
     };
+
+    useEffect(() => {
+        //Every time the current mark tagged element changes, try to scroll that element into view, as it may be
+        //off screen when the document is large.
+        const elements = document.getElementsByTagName('mark');
+        if (elements.length > 0) {
+            const element = elements[0];
+            element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
+    }, [selectedSearchItem]);
 
     return (
         <div className={classes.root}>

--- a/webapp/src/components/search/SearchRoom.tsx
+++ b/webapp/src/components/search/SearchRoom.tsx
@@ -48,12 +48,23 @@ export const SearchRoom: React.FC = () => {
     let metaData: ISearchMetaData = {};
 
     values.forEach((data) => {
-        data.matches.map((match) => {
-            if (match.id === selectedSearchItem) {
-                displayContent = match.content;
-                metaData = match.metadata;
-            }
-        });
+        // data.matches.map((match) => {
+        //     if (match.id === selectedSearchItem) {
+        //         displayContent = match.content;
+        //         metaData = match.metadata;
+        //     }
+        // });
+        if (data.filename === selectedSearchItem.filename) {
+            const regex = new RegExp(
+                `<PLACEHOLDER_${selectedSearchItem.id + 1}>(.*?)<\/PLACEHOLDER_${selectedSearchItem.id + 1}>`,
+            );
+            displayContent = [
+                data.placeholderMarkedText.replace(regex, (_match, p1: string) => {
+                    return `<mark>${p1}</mark>`;
+                }),
+            ];
+            metaData = data.matches[0].metadata;
+        }
     });
 
     const scrollViewTargetRef = React.useRef<HTMLDivElement>(null);
@@ -88,14 +99,14 @@ export const SearchRoom: React.FC = () => {
                             : <span>{metaData.source.url}</span>
                         </div>
                     )}
-                    {metaData.page_number !== undefined && (
+                    {/* {metaData.page_number !== undefined && (
                         <div>
                             <span>
                                 <b>Page Number</b>
                             </span>
                             : <span>{metaData.page_number}</span>
                         </div>
-                    )}
+                    )} */}
                 </div>
             </div>
             <div className={classes.input}></div>

--- a/webapp/src/components/search/search-list/SearchList.tsx
+++ b/webapp/src/components/search/search-list/SearchList.tsx
@@ -12,6 +12,7 @@ const useClasses = makeStyles({
         display: 'flex',
         flexShrink: 0,
         width: '320px',
+        height: '100%',
         backgroundColor: tokens.colorNeutralBackground4,
         flexDirection: 'column',
         ...Breakpoints.small({

--- a/webapp/src/components/search/search-list/SearchList.tsx
+++ b/webapp/src/components/search/search-list/SearchList.tsx
@@ -12,7 +12,7 @@ const useClasses = makeStyles({
         display: 'flex',
         flexShrink: 0,
         width: '320px',
-        height: '100%',
+        height: 'calc(100% - 44px)', //44px fixed height for tab list above this element.
         backgroundColor: tokens.colorNeutralBackground4,
         flexDirection: 'column',
         ...Breakpoints.small({

--- a/webapp/src/components/search/search-list/SearchListItem.tsx
+++ b/webapp/src/components/search/search-list/SearchListItem.tsx
@@ -87,7 +87,6 @@ export const SearchListItem: FC<ISearchListItemProps> = ({ label, id, filename, 
 
     const onClick = (_ev: any) => {
         dispatch(setSelectedSearchItem({ id, filename }));
-        document.getElementsByTagName('mark')[0].scrollIntoView();
     };
 
     return (

--- a/webapp/src/components/search/search-list/SearchListItem.tsx
+++ b/webapp/src/components/search/search-list/SearchListItem.tsx
@@ -1,10 +1,9 @@
 import { makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 
-import { FC } from 'react';
+import { FC, useId } from 'react';
 import { useAppDispatch } from '../../../redux/app/hooks';
-import { Breakpoints, SharedStyles } from '../../../styles';
 import { setSelectedSearchItem } from '../../../redux/features/search/searchSlice';
-import { useId } from 'react';
+import { Breakpoints, SharedStyles } from '../../../styles';
 
 const useClasses = makeStyles({
     root: {
@@ -77,16 +76,18 @@ const useClasses = makeStyles({
 
 interface ISearchListItemProps {
     label: string;
-    id: string;
+    id: number;
+    filename: string;
     isSelected: boolean;
 }
 
-export const SearchListItem: FC<ISearchListItemProps> = ({ label, id, isSelected }) => {
+export const SearchListItem: FC<ISearchListItemProps> = ({ label, id, filename, isSelected }) => {
     const classes = useClasses();
     const dispatch = useAppDispatch();
 
     const onClick = (_ev: any) => {
-        dispatch(setSelectedSearchItem(id));
+        dispatch(setSelectedSearchItem({ id, filename }));
+        document.getElementsByTagName('mark')[0].scrollIntoView();
     };
 
     return (
@@ -97,7 +98,7 @@ export const SearchListItem: FC<ISearchListItemProps> = ({ label, id, isSelected
             title={label}
             aria-label={label}
         >
-            {label}
+            <p dangerouslySetInnerHTML={{ __html: label }} />
         </div>
     );
 };

--- a/webapp/src/libs/hooks/useSearch.ts
+++ b/webapp/src/libs/hooks/useSearch.ts
@@ -25,6 +25,61 @@ export const useSearch = () => {
     const { instance, inProgress } = useMsal();
     const searchService = new SearchService();
 
+    const findPlaceholderWithContext = (text: string, contextWords = 4) => {
+        const pattern = /<PLACEHOLDER_\d+>(.*?)<\/PLACEHOLDER_\d+>/gi;
+
+        // Find all matches
+        const matches = [];
+        let match;
+
+        // Use exec to find all occurrences
+        while ((match = pattern.exec(text)) !== null) {
+            // Calculate the context tokens before and after the match
+            const startTokens = text.slice(0, match.index).trim().split(/\s+/);
+            const endTokens = text
+                .slice(match.index + match[0].length)
+                .trim()
+                .split(/\s+/);
+
+            // Get the required number of context words
+            const contextBefore = startTokens.slice(-contextWords).join(' ');
+            const contextAfter = endTokens.slice(0, contextWords).join(' ');
+
+            // Construct the full context string
+            const fullMatch = `${contextBefore} <b>${match[0]}</b> ${contextAfter}`.trim();
+            matches.push(fullMatch);
+        }
+
+        return matches;
+    };
+
+    const replaceMarksWithPlaceholders = (inputString: string, startingIncrement = 0) => {
+        let count = startingIncrement;
+
+        // Regex to match <span>anytextthere</span>
+        const regex = /<mark>(.*?)<\/mark>/g;
+
+        // Replace function that increments the count and keeps the inner text
+        const result = inputString.replace(regex, (_match, p1) => {
+            count++;
+            return `<PLACEHOLDER_${count}>${p1}</PLACEHOLDER_${count}>`;
+        });
+
+        return result;
+    };
+
+    const removePlaceholders = (inputString: string) => {
+        // Regex to match <PLACEHOLDER_X>...<PLACEHOLDER_X>
+        const regex = /<PLACEHOLDER_\d+>(.*?)<\/PLACEHOLDER_\d+>/g;
+
+        // Replace function that returns the inner content
+        const result = inputString.replace(regex, (_match, p1: string) => {
+            return p1; // Return the inner text
+        });
+
+        return result;
+    };
+
     const getResponse = async (specializationId: string, value: string) => {
         const searchAsk: IAskSearch = {
             specializationId,
@@ -35,7 +90,21 @@ export const useSearch = () => {
             await searchService
                 .getSearchResponseAsync(searchAsk, await AuthHelper.getSKaaSAccessToken(instance, inProgress))
                 .then((searchResult: SearchResponse) => {
-                    dispatch(setSearch(searchResult));
+                    const searchResultTransform = searchResult.value.map((value) => {
+                        const matches = value.matches
+                            .sort((a, b) => (a.metadata.page_number ?? 0) - (b.metadata.page_number ?? 0))
+                            .map((match) => match.content)
+                            .flat(2);
+                        const placeHolders = replaceMarksWithPlaceholders(matches.join('<br><br>'));
+                        return {
+                            ...value,
+                            placeholderMarkedText: placeHolders,
+                            entryPointList: findPlaceholderWithContext(placeHolders.replace(/<br\s*\/?>/gi, '')).map(
+                                (plc) => removePlaceholders(plc),
+                            ),
+                        };
+                    });
+                    dispatch(setSearch({ count: searchResult.count, value: searchResultTransform }));
                 });
         } catch (e: any) {
             const errorMessage = `Unable to search. Details: ${getErrorDetails(e)}`;

--- a/webapp/src/libs/hooks/useSearch.ts
+++ b/webapp/src/libs/hooks/useSearch.ts
@@ -25,6 +25,7 @@ export const useSearch = () => {
     const { instance, inProgress } = useMsal();
     const searchService = new SearchService();
 
+    // We want to get every instance of a placeholder tag, plus a few tokens of context for display in the sidebar.
     const findPlaceholderWithContext = (text: string, contextWords = 4) => {
         const pattern = /<PLACEHOLDER_\d+>(.*?)<\/PLACEHOLDER_\d+>/gi;
 
@@ -32,7 +33,6 @@ export const useSearch = () => {
         const matches = [];
         let match;
 
-        // Use exec to find all occurrences
         while ((match = pattern.exec(text)) !== null) {
             // Calculate the context tokens before and after the match
             const startTokens = text.slice(0, match.index).trim().split(/\s+/);
@@ -56,10 +56,11 @@ export const useSearch = () => {
     const replaceMarksWithPlaceholders = (inputString: string, startingIncrement = 0) => {
         let count = startingIncrement;
 
-        // Regex to match <span>anytextthere</span>
+        // Regex to match <mark>anytextthere</mark>
         const regex = /<mark>(.*?)<\/mark>/g;
 
         // Replace function that increments the count and keeps the inner text
+        // So for every <mark></mark>, we instead get <PLACEHOLDER_1></PLACEHOLDER_1>, <PLACEHOLDER_2></PLACEHOLDER_2>, etc...
         const result = inputString.replace(regex, (_match, p1) => {
             count++;
             return `<PLACEHOLDER_${count}>${p1}</PLACEHOLDER_${count}>`;

--- a/webapp/src/redux/features/search/SearchState.ts
+++ b/webapp/src/redux/features/search/SearchState.ts
@@ -2,19 +2,26 @@ import { ISearchValue } from '../../../libs/models/SearchResponse';
 
 export interface SearchState {
     selected: boolean;
-    searchData: SearchResponse;
-    selectedSearchItem: string;
+    searchData: SearchResponseTransform;
+    selectedSearchItem: { filename: string; id: number };
     selectedSpecializationId: string;
 }
 
 export const initialState: SearchState = {
     selected: false,
     searchData: { count: 0, value: [] },
-    selectedSearchItem: '',
+    selectedSearchItem: { filename: '', id: 0 },
     selectedSpecializationId: '',
 };
 
 export interface SearchResponse {
     count: number;
     value: ISearchValue[];
+}
+
+export type SearchValueExtended = ISearchValue & { placeholderMarkedText: string; entryPointList: string[] };
+
+export interface SearchResponseTransform {
+    count: number;
+    value: SearchValueExtended[];
 }

--- a/webapp/src/redux/features/search/SearchState.ts
+++ b/webapp/src/redux/features/search/SearchState.ts
@@ -2,7 +2,7 @@ import { ISearchValue } from '../../../libs/models/SearchResponse';
 
 export interface SearchState {
     selected: boolean;
-    searchData: SearchResponseTransform;
+    searchData: SearchResponseFormatted;
     selectedSearchItem: { filename: string; id: number };
     selectedSpecializationId: string;
 }
@@ -14,14 +14,17 @@ export const initialState: SearchState = {
     selectedSpecializationId: '',
 };
 
+//Raw response data from search API
 export interface SearchResponse {
     count: number;
     value: ISearchValue[];
 }
 
-export type SearchValueExtended = ISearchValue & { placeholderMarkedText: string; entryPointList: string[] };
+//Search value, augmented with extra data that makes it easier to enumerate every match and distinguish <mark>'s
+export type SearchValueFormatted = ISearchValue & { placeholderMarkedText: string; entryPointList: string[] };
 
-export interface SearchResponseTransform {
+//Search response, augmented with SearchValueFormatted overtop of the original ISearchValue
+export interface SearchResponseFormatted {
     count: number;
-    value: SearchValueExtended[];
+    value: SearchValueFormatted[];
 }

--- a/webapp/src/redux/features/search/searchSlice.ts
+++ b/webapp/src/redux/features/search/searchSlice.ts
@@ -1,11 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { initialState, SearchResponseTransform, SearchState } from './SearchState';
+import { initialState, SearchResponseFormatted, SearchState } from './SearchState';
 
 export const searchSlice = createSlice({
     name: 'search',
     initialState,
     reducers: {
-        setSearch: (state: SearchState, action: PayloadAction<SearchResponseTransform>) => {
+        setSearch: (state: SearchState, action: PayloadAction<SearchResponseFormatted>) => {
             state.searchData = action.payload;
         },
         setSelectedSearchItem: (state: SearchState, action: PayloadAction<{ filename: string; id: number }>) => {

--- a/webapp/src/redux/features/search/searchSlice.ts
+++ b/webapp/src/redux/features/search/searchSlice.ts
@@ -1,14 +1,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { initialState, SearchResponse, SearchState } from './SearchState';
+import { initialState, SearchResponseTransform, SearchState } from './SearchState';
 
 export const searchSlice = createSlice({
     name: 'search',
     initialState,
     reducers: {
-        setSearch: (state: SearchState, action: PayloadAction<SearchResponse>) => {
+        setSearch: (state: SearchState, action: PayloadAction<SearchResponseTransform>) => {
             state.searchData = action.payload;
         },
-        setSelectedSearchItem: (state: SearchState, action: PayloadAction<string>) => {
+        setSelectedSearchItem: (state: SearchState, action: PayloadAction<{ filename: string; id: number }>) => {
             state.selectedSearchItem = action.payload;
         },
         setSearchSelected: (


### PR DESCRIPTION
### Motivation and Context

The previous view enumerating search matches is undesirable. The results were being enumerated by Match-1, Match-2, Match-3, which doesn't show you anything about what the match contains. Also, each match contains different chunks of text. The PO would prefer a search feature similar to MS Word, where you see all results in a straightforward list and can tab through them one at a time.

### Description

* The callback for the search request will now do some additional processing to the results. It will use regex patterns to find every instance of a mark tag (which indicates a search match) and replace them with tags in the form of placeholder_n. These incrementing placeholder tags can later be used to determine the currently selected match, and then replace the tag with a mark to highlight it.
* The search results list will now include every result across all "matches" in one long list. Instead of displaying Match-n, it will display the text that was matched plus a few surrounding tokens for context.
* Instead of displaying the document in separate chunks, all chunks are displayed at once in the right pane.
* Clicking on a match will fetch an element by tag (mark) and use document.scrollIntoView to focus it. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
