### PR TITLE
Add cursor: pointer to avatar menu

### DIFF
--- a/webapp/src/components/header/UserSettingsMenu.tsx
+++ b/webapp/src/components/header/UserSettingsMenu.tsx
@@ -27,6 +27,7 @@ import { SettingsDialog } from './settings-dialog/SettingsDialog';
 export const useClasses = makeStyles({
     root: {
         marginRight: tokens.spacingHorizontalXL,
+        cursor: 'pointer',
     },
     persona: {
         ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingVerticalMNudge),


### PR DESCRIPTION
Super small PR.. 
![image](https://github.com/user-attachments/assets/2abd16f4-fa60-4550-b8cb-b4fcdc957012)

### Motivation and Context
It is not always clear that the avatar is clickable in the top right of the application, adding the `cursor: pointer` css to this avoids potential confusion.

### Description
Just adding a pointer which is the universal cursor for clickable.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
