### PR TITLE
refactor: remove redundant calls to session repository

### DIFF
--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -105,7 +105,7 @@ public class ChatHistoryController : ControllerBase
         {
             return this.BadRequest("Chat session parameters cannot be null.");
         }
-        // Create a new chat session
+
         var systemDescription = this._promptOptions.SystemDescription;
         var newChat = new ChatSession(
             chatParameters.Title,
@@ -114,14 +114,6 @@ public class ChatHistoryController : ControllerBase
             chatParameters.Id
         );
         await this._sessionRepository.CreateAsync(newChat);
-        ChatSession? chat = null;
-        if (await this._sessionRepository.TryFindByIdAsync(newChat.Id, callback: v => chat = v))
-        {
-            chat!.Title = chatParameters.Title;
-            chat!.SystemDescription = systemDescription;
-            await this._sessionRepository.UpsertAsync(chat);
-        }
-        //Save prompt - End
 
         Specialization? specialization = null;
         if (chatParameters.specializationId != "general")


### PR DESCRIPTION
### Motivation and Context

The current flow in this proposal is as follows:
- initialize a `ChatSession`
- push the new `ChatSession` to the database
- fetch the newly created `ChatSession`
- overwrite `Title` and `SystemDescription` properties
- upsert that same `ChatSession` to the database

This reads like we intended to allow a user to call the same endpoint to create or update a `ChatSession`. We already have `[PATCH] /chats/{chatId}` however.

### Description

- refactor: remove redundant calls to session repo

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
