### PR TITLE
Specialization order bugfix

### DIFF
--- a/webapi/Models/Response/QSpecializationResponse.cs
+++ b/webapi/Models/Response/QSpecializationResponse.cs
@@ -96,14 +96,16 @@ public class QSpecializationResponse
     public int? DocumentCount { get; set; } = 0;
 
     /// <summary>
+    /// Order of the specialization.
+    /// </summary>
+    [JsonPropertyName("order")]
+    public int? Order { get; set; } = 0;
+
+
+    /// <summary>
     /// List of group memberships for the user.
     /// </summary>
     public IList<string> GroupMemberships { get; set; } = new List<string>();
-
-    /// <summary>
-    /// Order of the specialization.
-    /// </summary>
-    public int? Order { get; set; } = 0;
 
     /// <summary>
     /// Creates new instance from SpecializationSource.

--- a/webapi/Models/Response/QSpecializationResponse.cs
+++ b/webapi/Models/Response/QSpecializationResponse.cs
@@ -101,7 +101,6 @@ public class QSpecializationResponse
     [JsonPropertyName("order")]
     public int? Order { get; set; } = 0;
 
-
     /// <summary>
     /// List of group memberships for the user.
     /// </summary>


### PR DESCRIPTION
### Description

Specializations are not returning with "order" in response. Added order `JsonPropertyName` to `SpecializationResponse`.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
