### PR TITLE
refactor: remove redundant message repo calls

### DIFF
--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -190,21 +190,6 @@ public class ChatHistoryController : ControllerBase
             ChatSession? chat = null;
             if (await this._sessionRepository.TryFindByIdAsync(chatParticipant.ChatId, callback: v => chat = v))
             {
-                if (
-                    Regex.IsMatch(
-                        chat!.Title,
-                        @"Q-Pilot @ [0-9]{1,2}\/[0-9]{1,2}\/[0-9]{1,4}, [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [A,P]M"
-                    )
-                )
-                {
-                    var messagesInThisChat = await this._messageRepository.FindByChatIdAsync(chatParticipant.ChatId);
-                    var firstUserMessage = messagesInThisChat.Where(m => m.UserId != "Bot").MinBy(m => m.Timestamp);
-                    if (firstUserMessage != null)
-                    {
-                        chat!.Title = firstUserMessage.Content;
-                    }
-                }
-
                 chats.Add(chat!);
             }
             else

--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Auth;


### PR DESCRIPTION
### Motivation and Context

The chat client currently calculates the chat title based on [message states](https://github.com/Quartech/chat-copilot/blob/6f8afa641fb6f7865a92fee68191c3dc90566fdc/webapp/src/libs/hooks/useChat.ts#L642) making this calculation on the backend redundant.

### Description

- refactor: remove redundant message repo calls

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
