### PR TITLE
Wrong specialization showing when creating new chat

### DIFF
--- a/webapp/src/components/chat/Chat.tsx
+++ b/webapp/src/components/chat/Chat.tsx
@@ -36,7 +36,6 @@ const Chat = ({
             <LoadingSpinner />
             <Header appState={appState} setAppState={setAppState} showPluginsAndSettings={true} />
             {appState === AppState.ProbeForBackend && <BackendProbe onBackendFound={onBackendFound} />}
-
             <>
                 {hasAccess ? (
                     <>

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -15,7 +15,7 @@ import { ChatSuggestionList } from './suggestions/ChatSuggestionList';
 
 const useClasses = makeStyles({
     root: {
-        ...shorthands.overflow('hidden'),
+        overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { makeStyles, mergeClasses, Persona, shorthands, Text, tokens } from '@fluentui/react-components';
 import { ShieldTask16Regular } from '@fluentui/react-icons';
 import { FC, useState } from 'react';
@@ -115,11 +116,29 @@ export const ChatListItem: FC<IChatListItemProps> = ({
 
     const showPreview = !features[FeatureKeys.SimplifiedExperience].enabled && preview;
     const showActions = features[FeatureKeys.SimplifiedExperience].enabled && isSelected;
+    // for some reason the below rule is enforced, but conversations[id].specializationId is nullable.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const specializationId = React.useMemo(() => conversations[id]?.specializationId, [conversations[id]]);
 
     const [editingTitle, setEditingTitle] = useState(false);
 
+    React.useEffect(() => {
+        if (specializationId) {
+            const foundSpecialization = specializations.find(
+                (specialization) => specialization.id === specializationId,
+            );
+            if (foundSpecialization) {
+                dispatch(setChatSpecialization(foundSpecialization));
+            }
+        } else {
+            // defaults to general chat if none are selected (because if you type in the chat without selecting a specialization, it will be proceed as general)
+            const generalSpecialization = specializations.find((specialization) => specialization.id === 'general');
+            generalSpecialization && dispatch(setChatSpecialization(generalSpecialization));
+        }
+    }, [conversations[id]]);
+
     const onClick = (_ev: any) => {
-        const specializationId = conversations[id].specializationId;
+        // const specializationId = conversations[id].specializationId;
         if (specializationId) {
             const foundSpecialization = specializations.find(
                 (specialization) => specialization.id === specializationId,

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -137,8 +137,7 @@ export const ChatListItem: FC<IChatListItemProps> = ({
         }
     }, [conversations[id]]);
 
-    const onClick = (_ev: any) => {
-        // const specializationId = conversations[id].specializationId;
+    const onClick = (_ev: React.MouseEvent<HTMLElement>) => {
         if (specializationId) {
             const foundSpecialization = specializations.find(
                 (specialization) => specialization.id === specializationId,

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -135,6 +135,8 @@ export const ChatListItem: FC<IChatListItemProps> = ({
             const generalSpecialization = specializations.find((specialization) => specialization.id === 'general');
             generalSpecialization && dispatch(setChatSpecialization(generalSpecialization));
         }
+        // only want this to fire when the convversation changes
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [conversations[id]]);
 
     const onClick = (_ev: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
### Motivation and Context
There was previously a bug when starting a new chat from an existing chat window. If one was to create a New Chat while viewing an older chat with a specialization selected, it would appear in the top bar of the new chat window. Might be easier to try than explain.

1. Goto dev
2. Select an old chat with a specialization other than general
3. Create a new chat while viewing the old chat
4. Observe the top right specialization selection
5. Do not select a specialization and type test in the chat bar
6. Hit enter
7. Mismatch between specializations are present

Additionally, we should show that General is selected by default - this is now the case.

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  9. What problem does it solve?
  10. What scenario does it contribute to?
  11. If it fixes an open issue, please link to the issue here.
-->

### Description
Added logic so the appropriate specialization is reflected on the front end for various scenarios. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
