### PR TITLE
Query chat sessions as batch

### DIFF
--- a/webapi/Controllers/ChatHistoryController.cs
+++ b/webapi/Controllers/ChatHistoryController.cs
@@ -179,23 +179,9 @@ public class ChatHistoryController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetAllChatSessionsAsync()
     {
-        // Get all participants that belong to the user.
-        // Then get all the chats from the list of participants.
         var chatParticipants = await this._participantRepository.FindByUserIdAsync(this._authInfo.UserId);
 
-        var chats = new List<ChatSession>();
-        foreach (var chatParticipant in chatParticipants)
-        {
-            ChatSession? chat = null;
-            if (await this._sessionRepository.TryFindByIdAsync(chatParticipant.ChatId, callback: v => chat = v))
-            {
-                chats.Add(chat!);
-            }
-            else
-            {
-                this._logger.LogDebug("Failed to find chat session with id {0}", chatParticipant.ChatId);
-            }
-        }
+        var chats = await this._sessionRepository.FindByIdsAsync(chatParticipants.Select(cp => cp.ChatId));
 
         return this.Ok(chats);
     }

--- a/webapi/Storage/ChatSessionRepository.cs
+++ b/webapi/Storage/ChatSessionRepository.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using CopilotChat.WebApi.Models.Storage;
 
 namespace CopilotChat.WebApi.Storage;
@@ -15,4 +17,15 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// <param name="storageContext">The storage context.</param>
     public ChatSessionRepository(IStorageContext<ChatSession> storageContext)
         : base(storageContext) { }
+
+    /// <summary>
+    /// Retrieves a list of chat sessions.
+    /// </summary>
+    /// <param name="chatIds">List of ChatSession IDs to retrieve.</param>
+    /// <returns>A list of ChatSessions.</returns>
+    public Task<IEnumerable<ChatSession>> FindByIdsAsync(IEnumerable<string> chatIds)
+    {
+        var chatSet = new HashSet<string>(chatIds);
+        return base.StorageContext.QueryEntitiesAsync(e => chatSet.Contains(e.Partition));
+    }
 }

--- a/webapi/Storage/ChatSessionRepository.cs
+++ b/webapi/Storage/ChatSessionRepository.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using CopilotChat.WebApi.Models.Storage;
 
 namespace CopilotChat.WebApi.Storage;
@@ -17,13 +15,4 @@ public class ChatSessionRepository : Repository<ChatSession>
     /// <param name="storageContext">The storage context.</param>
     public ChatSessionRepository(IStorageContext<ChatSession> storageContext)
         : base(storageContext) { }
-
-    /// <summary>
-    /// Retrieves all chat sessions.
-    /// </summary>
-    /// <returns>A list of ChatMessages.</returns>
-    public Task<IEnumerable<ChatSession>> GetAllChatsAsync()
-    {
-        return base.StorageContext.QueryEntitiesAsync(e => true);
-    }
 }


### PR DESCRIPTION
### Motivation and Context

Instead of querying each `ChatSession` individually, `[Get] /chats` can send a single query with a list of target `chatIds`.

`GetAllChatAsync()` was not being used anywhere in code and was removed. This is not a very performant query. We should consider pagination if we are going to serve the user with a list of objects in the future.

Pagination will be introduced in a future proposal.

### Description

- refactor: remove GetAllChatAsync
- feat: create FindByIdsAsync
- refactor: call FindByIdsAsync instead of looping through each chatId

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
