### PR TITLE
feat: update chat session title on first message

### DIFF
--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -124,6 +124,7 @@ export const ChatRoom: React.FC = () => {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
             chat.editChat(selectedId, title, conversation.systemDescription, conversation.memoryBalance);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [messages]);
 
     const handleSubmit = async (options: GetResponseOptions) => {

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -120,7 +120,7 @@ export const ChatRoom: React.FC = () => {
         const conversation = conversations[selectedId];
         const title = getFriendlyChatName(conversation);
 
-        if (title != "New Chat" && conversation.title != title && conversation.createdOnServer) {
+        if (title != 'New Chat' && conversation.title != title && conversation.createdOnServer) {
             //eslint-disable-next-line @typescript-eslint/no-floating-promises
             chat.editChat(selectedId, title, conversation.systemDescription, conversation.memoryBalance);
         }

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -3,7 +3,7 @@
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import React, { useState } from 'react';
 import { SpecializationCardList } from '../../components/specialization/SpecializationCardList';
-import { GetResponseOptions, useChat } from '../../libs/hooks/useChat';
+import { getFriendlyChatName, GetResponseOptions, useChat } from '../../libs/hooks/useChat';
 import { ChatMessageType } from '../../libs/models/ChatMessage';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
@@ -115,6 +115,16 @@ export const ChatRoom: React.FC = () => {
             setShowSpecialization(false);
         }
     }, [messages, selectedId, conversations, showSpecialization]);
+
+    React.useEffect(() => {
+        const conversation = conversations[selectedId];
+        const title = getFriendlyChatName(conversation);
+
+        if (title != "New Chat" && conversation.title != title && conversation.createdOnServer) {
+            //eslint-disable-next-line @typescript-eslint/no-floating-promises
+            chat.editChat(selectedId, title, conversation.systemDescription, conversation.memoryBalance);
+        }
+    }, [messages]);
 
     const handleSubmit = async (options: GetResponseOptions) => {
         await chat.getResponse(options);


### PR DESCRIPTION
### Motivation and Context

The client should be making requests to update the chat session when the first user message is sent.

### Description

- feat: update chat session title on first message sent

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
