### PR TITLE
[Bug Fix] Fix specialization display bug when loading chat 

### DIFF
--- a/webapp/src/components/chat/ChatWindow.tsx
+++ b/webapp/src/components/chat/ChatWindow.tsx
@@ -91,7 +91,7 @@ export const ChatWindow: React.FC = () => {
         setSelectedTab(data.value);
     };
 
-    // Set the chat specialization based on the conversation specialization, esnures UI is in sync with current selected chat
+    // Set the chat specialization based on the conversation specialization, ensures UI is in sync with current selected chat
     React.useEffect(() => {
         if (conversationSpecialization) {
             const specializationMatch = specializations.find((spec) => spec.id === conversationSpecialization);

--- a/webapp/src/components/chat/ChatWindow.tsx
+++ b/webapp/src/components/chat/ChatWindow.tsx
@@ -80,6 +80,7 @@ export const ChatWindow: React.FC = () => {
     const { features } = useAppSelector((state: RootState) => state.app);
     const { conversations, selectedId } = useAppSelector((state: RootState) => state.conversations);
     const botResponseStatus = conversations[selectedId].botResponseStatus;
+    const conversationSpecialization = conversations[selectedId].specializationId;
     const [selectedTab, setSelectedTab] = React.useState<TabValue>(ChatWindowTabEnum.CHAT);
     const showShareBotMenu = features[FeatureKeys.BotAsDocs].enabled || features[FeatureKeys.MultiUserChat].enabled;
     const chatName = conversations[selectedId].title;
@@ -89,6 +90,20 @@ export const ChatWindow: React.FC = () => {
     const onTabSelect: SelectTabEventHandler = (_event, data) => {
         setSelectedTab(data.value);
     };
+
+    // Set the chat specialization based on the conversation specialization, esnures UI is in sync with current selected chat
+    React.useEffect(() => {
+        if (conversationSpecialization) {
+            const specializationMatch = specializations.find((spec) => spec.id === conversationSpecialization);
+            specializationMatch && dispatch(setChatSpecialization(specializationMatch));
+        } else {
+            const generalSpecMatch = specializations.find((spec) => spec.id === 'general');
+            generalSpecMatch && dispatch(setChatSpecialization(generalSpecMatch));
+        }
+        // only want to fire when conversationSpecialization changes
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [conversationSpecialization]);
+
     const onNewChatClick = () => {
         chat.createChat(chatSpecialization?.id);
         if (chatSpecialization) {

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -116,30 +116,11 @@ export const ChatListItem: FC<IChatListItemProps> = ({
 
     const showPreview = !features[FeatureKeys.SimplifiedExperience].enabled && preview;
     const showActions = features[FeatureKeys.SimplifiedExperience].enabled && isSelected;
-    // for some reason the below rule is enforced, but conversations[id].specializationId is nullable.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const specializationId = React.useMemo(() => conversations[id]?.specializationId, [conversations, id]);
 
     const [editingTitle, setEditingTitle] = useState(false);
 
-    React.useEffect(() => {
-        if (specializationId) {
-            const foundSpecialization = specializations.find(
-                (specialization) => specialization.id === specializationId,
-            );
-            if (foundSpecialization) {
-                dispatch(setChatSpecialization(foundSpecialization));
-            }
-        } else {
-            // defaults to general chat if none are selected (because if you type in the chat without selecting a specialization, it will be proceed as general)
-            const generalSpecialization = specializations.find((specialization) => specialization.id === 'general');
-            generalSpecialization && dispatch(setChatSpecialization(generalSpecialization));
-        }
-        // only want this to fire when the spec/convo changes
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [specializationId]);
-
     const onClick = (_ev: React.MouseEvent<HTMLElement>) => {
+        const specializationId = conversations[id].specializationId;
         if (specializationId) {
             const foundSpecialization = specializations.find(
                 (specialization) => specialization.id === specializationId,


### PR DESCRIPTION
After further review of previous work in DEV:

- logic should be moved to `ChatWindow` instead of executing on `ChatListItem`
- `useMemo` is not required on `conversationSpecialization` - not complex enough to warrant . See line 82 for similar logic
- fixes small bug on displaying wrong specialization on initial load
