### PR TITLE
Reconfig SignalR KeepAlive Ping / Timeout

### DIFF
--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -54,7 +54,7 @@ const setupSignalRConnectionToChatHub = () => {
 
     // Note: to keep the connection open the serverTimeout should be
     // larger than the KeepAlive value that is set on the server
-    hubConnection.keepAliveIntervalInMilliseconds = 30000;
+    hubConnection.keepAliveIntervalInMilliseconds = 20000;
     hubConnection.serverTimeoutInMilliseconds = 120000;
 
     return hubConnection;

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -55,7 +55,7 @@ const setupSignalRConnectionToChatHub = () => {
     // Note: to keep the connection open the serverTimeout should be
     // larger than the KeepAlive value that is set on the server
     hubConnection.keepAliveIntervalInMilliseconds = 30000;
-    hubConnection.serverTimeoutInMilliseconds = 60000;
+    hubConnection.serverTimeoutInMilliseconds = 120000;
 
     return hubConnection;
 };

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -54,8 +54,7 @@ const setupSignalRConnectionToChatHub = () => {
 
     // Note: to keep the connection open the serverTimeout should be
     // larger than the KeepAlive value that is set on the server
-    // keepAliveIntervalInMilliseconds default is 15000 and we are using default
-    // serverTimeoutInMilliseconds default is 30000 and we are using 60000 set below
+    hubConnection.keepAliveIntervalInMilliseconds = 30000;
     hubConnection.serverTimeoutInMilliseconds = 60000;
 
     return hubConnection;


### PR DESCRIPTION
### Motivation and Context
When user's leave their browser open for sometime, SignalR would successfully reconnect; however, require a refresh in order for the app to work again. Without a refresh the app would simply say `Calling the kernal`.

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
Increased the timeout to 2 minutes, and configured the keep alive ping to send every 20s. This seems to stop the app from timing out while navigating other applications/tabs. 

These numbers can be adjusted if need to be.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
