### PR TITLE
Sort chat list by most recently sent message

### DIFF
--- a/webapi/Controllers/ChatController.cs
+++ b/webapi/Controllers/ChatController.cs
@@ -185,6 +185,8 @@ public class ChatController : ControllerBase, IDisposable
                 Variables = contextVariables.Select(v => new KeyValuePair<string, object?>(v.Key, v.Value)),
             };
 
+        chat.LastUpdatedTimestamp = DateTimeOffset.Now;
+        await chatSessionRepository.UpsertAsync(chat);
         // Broadcast AskResult to all users
         await messageRelayHubContext
             .Clients.Group(chatIdString)

--- a/webapi/Models/Storage/ChatSession.cs
+++ b/webapi/Models/Storage/ChatSession.cs
@@ -70,6 +70,11 @@ public class ChatSession : IStorageEntity
     public string specializationId { get; set; }
 
     /// <summary>
+    /// Last time this chat was messaged.
+    /// </summary>
+    public DateTimeOffset LastUpdatedTimestamp { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ChatSession"/> class.
     /// </summary>
     /// <param name="title">The title of the chat.</param>
@@ -83,5 +88,6 @@ public class ChatSession : IStorageEntity
         this.SystemDescription = systemDescription;
         this.Version = CurrentVersion;
         this.specializationId = specializationId;
+        this.LastUpdatedTimestamp = DateTimeOffset.Now;
     }
 }

--- a/webapp/src/components/chat/chat-list/ChatList.tsx
+++ b/webapp/src/components/chat/chat-list/ChatList.tsx
@@ -112,7 +112,7 @@ export const ChatList: FC = () => {
                 return -1;
             }
             // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-            return conversations[a].lastUpdatedTimestamp - conversations[b].lastUpdatedTimestamp;
+            return conversations[b].lastUpdatedTimestamp - conversations[a].lastUpdatedTimestamp;
         });
 
         // Add conversations to sortedConversations in the order of sortedIds.

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { makeStyles, mergeClasses, Persona, shorthands, Text, tokens } from '@fluentui/react-components';
 import { ShieldTask16Regular } from '@fluentui/react-icons';
-import { FC, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { useChat } from '../../../libs/hooks';
 import { AlertType } from '../../../libs/models/AlertType';
 import { useAppDispatch, useAppSelector } from '../../../redux/app/hooks';

--- a/webapp/src/components/chat/chat-list/ChatListSection.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListSection.tsx
@@ -78,7 +78,7 @@ export const ChatListSection: React.FC<IChatListSectionProps> = ({ header, conve
                         key={id}
                         isSelected={isSelected}
                         header={getFriendlyChatName(convo)}
-                        timestamp={convo.lastUpdatedTimestamp ?? (messages.length > 0 ? lastMessage.timestamp : 0)} //Note: using 0 as a default unix epoch time value here
+                        timestamp={convo.lastUpdatedTimestamp ?? 0} //Note: using 0 as a default unix epoch time value here
                         preview={
                             messages.length > 0
                                 ? lastMessage.type === ChatMessageType.Document

--- a/webapp/src/libs/hooks/useAppLoader.ts
+++ b/webapp/src/libs/hooks/useAppLoader.ts
@@ -10,6 +10,7 @@ import { setSelectedConversation } from '../../redux/features/conversations/conv
 import { AuthHelper } from '../auth/AuthHelper';
 import { UserSettingsResponse } from '../models/UserSettings';
 import { GraphService } from '../services/GraphService';
+import { maxBy } from '../utils/HelperMethods';
 import { useChat } from './useChat';
 import { useFile } from './useFile';
 import { useSettings } from './useSettings';
@@ -147,8 +148,8 @@ export const useAppLoader = (): [AppState, Dispatch<SetStateAction<AppState>>] =
     };
 
     const loadInitialChat = async () => {
-        const firstConvo = Object.values(conversations)[0];
-        if (firstConvo.createdOnServer) {
+        const firstConvo = maxBy(Object.values(conversations), (chatState) => chatState.lastUpdatedTimestamp ?? 0);
+        if (firstConvo?.createdOnServer) {
             try {
                 await chat.loadChatMessagesByChatId(firstConvo.id);
                 dispatch(setSelectedConversation(firstConvo.id));

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -13,6 +13,7 @@ import {
     addConversation,
     addMessageToConversationFromUser,
     deleteConversation,
+    editConversationLastUpdate,
     editConversationSpecialization,
     setConversations,
     updateBotResponseStatus,
@@ -101,6 +102,7 @@ export const useChat = () => {
             specializationId,
             suggestions: [],
             createdOnServer: false,
+            lastUpdatedTimestamp: new Date().getTime(),
         };
 
         dispatch(addConversation(newChat));
@@ -141,6 +143,7 @@ export const useChat = () => {
                     specializationId,
                     suggestions: [],
                     createdOnServer: true,
+                    lastUpdatedTimestamp: new Date().getTime(),
                 };
                 dispatch(addConversation(newChat));
                 return newChat.id;
@@ -215,7 +218,7 @@ export const useChat = () => {
         if (kernelArguments) {
             ask.variables.push(...kernelArguments);
         }
-
+        dispatch(editConversationLastUpdate({ id: chatId, newDate: new Date().getTime() }));
         try {
             const conversation = conversations[currentConversationId];
             if (!conversation.createdOnServer) {
@@ -302,6 +305,7 @@ export const useChat = () => {
                         specializationId: chatSession.specializationId,
                         createdOnServer: true,
                         suggestions: [],
+                        lastUpdatedTimestamp: new Date(chatSession.lastUpdatedTimestamp ?? 0).getTime(),
                     };
                 }
 

--- a/webapp/src/libs/models/ChatSession.ts
+++ b/webapp/src/libs/models/ChatSession.ts
@@ -11,6 +11,7 @@ export interface IChatSession {
     memoryBalance: number;
     enabledPlugins: string[];
     specializationId?: string;
+    lastUpdatedTimestamp?: string;
 }
 
 export interface ICreateChatSessionResponse {

--- a/webapp/src/libs/utils/HelperMethods.ts
+++ b/webapp/src/libs/utils/HelperMethods.ts
@@ -4,4 +4,18 @@ const getUUID = (): string => {
     return v4();
 };
 
-export { getUUID };
+const maxBy = <T>(array: T[], iteratee: (i: T) => number | string) => {
+    let result;
+    let computed;
+    for (const value of array) {
+        const current = iteratee(value);
+
+        if (computed === undefined ? current === current : current > computed) {
+            computed = current;
+            result = value;
+        }
+    }
+    return result;
+};
+
+export { getUUID, maxBy };

--- a/webapp/src/redux/features/conversations/ConversationsState.ts
+++ b/webapp/src/redux/features/conversations/ConversationsState.ts
@@ -26,6 +26,11 @@ export interface ConversationTitleChange {
     newTitle: string;
 }
 
+export interface ConversationUpdateTimestampChange {
+    id: string;
+    newDate: number;
+}
+
 export interface ConversationInputChange {
     id: string;
     newInput: string;

--- a/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -13,6 +13,7 @@ import {
     ConversationSuggestionsChange,
     ConversationSystemDescriptionChange,
     ConversationTitleChange,
+    ConversationUpdateTimestampChange,
     initialState,
     UpdatePluginStatePayload,
 } from './ConversationsState';
@@ -29,6 +30,13 @@ export const conversationsSlice = createSlice({
             const newTitle = action.payload.newTitle;
             state.conversations[id].title = newTitle;
             frontLoadChat(state, id);
+        },
+        editConversationLastUpdate: (
+            state: ConversationsState,
+            action: PayloadAction<ConversationUpdateTimestampChange>,
+        ) => {
+            const id = action.payload.id;
+            state.conversations[id].lastUpdatedTimestamp = action.payload.newDate;
         },
         editConversationSpecialization: (
             state: ConversationsState,
@@ -324,6 +332,7 @@ export const {
     editConversationSpecialization,
     updateSuggestions,
     deleteConversationHistory,
+    editConversationLastUpdate,
 } = conversationsSlice.actions;
 
 export default conversationsSlice.reducer;


### PR DESCRIPTION
### Motivation and Context
Chat list was being sorted arbitrarily between refreshes and the default chat was selected arbitrarily as well. We will instead sort the chat list by most recently updated and use the most recent chat as the default.

### Description

* Backend now stores the LastUpdatedTimestamp, which is set on session creation and when sending a new message.
* Frontend will obtain the backend's copy of this value when retrieving chats from the GET endpoint, but since this only happens once on page load it will also update redux store when creating a new chat or sending a new message.
* There was existing code for sorting chats by timestamp, but I reversed order to but most recent at  the top. This seemed more intuitive to me.
* Added maxBy helper method to get object from array by maximal property. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
