### PR TITLE
Add modal to display re connection warning 

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -18,7 +18,7 @@ export const useClasses = makeStyles({
         flexDirection: 'column',
         height: '100vh',
         width: '100%',
-        ...shorthands.overflow('hidden'),
+        overflow: 'hidden',
     },
     header: {
         alignItems: 'center',

--- a/webapp/src/components/chat/Chat.tsx
+++ b/webapp/src/components/chat/Chat.tsx
@@ -6,7 +6,7 @@ import Alerts from '../shared/Alerts';
 import LoadingSpinner from '../shared/LoadingSpinner';
 import { BackendProbe, ChatView, Error, Loading, Unauth } from '../views';
 import { useAppSelector } from '../../redux/app/hooks';
-import { Modal } from '../shared/Modal';
+import { ReloadModal } from '../shared/ReloadModal';
 
 const Chat = ({
     classes,
@@ -35,7 +35,7 @@ const Chat = ({
     return (
         <div className={classes.container}>
             <Alerts />
-            <Modal />
+            <ReloadModal />
             <LoadingSpinner />
             <Header appState={appState} setAppState={setAppState} showPluginsAndSettings={true} />
             {appState === AppState.ProbeForBackend && <BackendProbe onBackendFound={onBackendFound} />}

--- a/webapp/src/components/chat/Chat.tsx
+++ b/webapp/src/components/chat/Chat.tsx
@@ -6,6 +6,7 @@ import Alerts from '../shared/Alerts';
 import LoadingSpinner from '../shared/LoadingSpinner';
 import { BackendProbe, ChatView, Error, Loading, Unauth } from '../views';
 import { useAppSelector } from '../../redux/app/hooks';
+import { Modal } from '../shared/Modal';
 
 const Chat = ({
     classes,
@@ -30,9 +31,11 @@ const Chat = ({
                   AppState.LoadingChats,
         );
     }, [setAppState]);
+
     return (
         <div className={classes.container}>
             <Alerts />
+            <Modal />
             <LoadingSpinner />
             <Header appState={appState} setAppState={setAppState} showPluginsAndSettings={true} />
             {appState === AppState.ProbeForBackend && <BackendProbe onBackendFound={onBackendFound} />}

--- a/webapp/src/components/shared/Modal.tsx
+++ b/webapp/src/components/shared/Modal.tsx
@@ -14,8 +14,11 @@ export const Modal: React.FC = () => {
                         <DialogActions>
                             <Button
                                 onClick={() => {
-                                    dialog.onConfirm && dialog.onConfirm();
-                                    dialog.reloadOnConfirm && window.location.reload();
+                                    if (dialog.reloadOnConfirm) {
+                                        window.location.reload();
+                                    } else if (dialog.onConfirm) {
+                                        dialog.onConfirm();
+                                    }
                                 }}
                                 appearance="primary"
                             >

--- a/webapp/src/components/shared/Modal.tsx
+++ b/webapp/src/components/shared/Modal.tsx
@@ -1,0 +1,30 @@
+import { Button, Dialog, DialogActions, DialogBody, DialogContent, DialogSurface } from '@fluentui/react-components';
+import React from 'react';
+import { useAppSelector } from '../../redux/app/hooks';
+import { RootState } from '../../redux/app/store';
+
+export const Modal: React.FC = () => {
+    const { dialog } = useAppSelector((state: RootState) => state.app);
+    return (
+        !!dialog && (
+            <Dialog open>
+                <DialogSurface>
+                    <DialogBody>
+                        <DialogContent>{dialog.text}</DialogContent>
+                        <DialogActions>
+                            <Button
+                                onClick={() => {
+                                    dialog.onConfirm && dialog.onConfirm();
+                                    dialog.reloadOnConfirm && window.location.reload();
+                                }}
+                                appearance="primary"
+                            >
+                                Ok
+                            </Button>
+                        </DialogActions>
+                    </DialogBody>
+                </DialogSurface>
+            </Dialog>
+        )
+    );
+};

--- a/webapp/src/components/shared/Modal.tsx
+++ b/webapp/src/components/shared/Modal.tsx
@@ -1,33 +1,49 @@
 import { Button, Dialog, DialogActions, DialogBody, DialogContent, DialogSurface } from '@fluentui/react-components';
 import React from 'react';
-import { useAppSelector } from '../../redux/app/hooks';
-import { RootState } from '../../redux/app/store';
 
-export const Modal: React.FC = () => {
-    const { dialog } = useAppSelector((state: RootState) => state.app);
+export interface IModalProps {
+    open: boolean;
+    text: string;
+    onConfirm?: () => void;
+    onClose?: () => void;
+}
+
+/**
+ * Base Modal component
+ * @param {boolean} open - Boolean value to show/hide modal.
+ * @param {string} text - Text to be displayed in modal.
+ * @param {function} onConfirm - Callback function to be called on confirm button click.
+ * @param {function} onClose - Callback function to be called on close button click.
+ * @returns {JSX.Element} Modal component.
+ */
+export const Modal: React.FC<IModalProps> = ({ open, text, onConfirm, onClose }) => {
     return (
-        !!dialog && (
-            <Dialog open>
-                <DialogSurface>
-                    <DialogBody>
-                        <DialogContent>{dialog.text}</DialogContent>
-                        <DialogActions>
+        <Dialog open={open}>
+            <DialogSurface>
+                <DialogBody>
+                    <DialogContent>{text}</DialogContent>
+                    <DialogActions>
+                        <Button
+                            onClick={() => {
+                                onConfirm && onConfirm();
+                            }}
+                            appearance="primary"
+                        >
+                            Ok
+                        </Button>
+                        {!!onClose && (
                             <Button
                                 onClick={() => {
-                                    if (dialog.reloadOnConfirm) {
-                                        window.location.reload();
-                                    } else if (dialog.onConfirm) {
-                                        dialog.onConfirm();
-                                    }
+                                    onClose();
                                 }}
-                                appearance="primary"
+                                appearance="secondary"
                             >
-                                Ok
+                                Close
                             </Button>
-                        </DialogActions>
-                    </DialogBody>
-                </DialogSurface>
-            </Dialog>
-        )
+                        )}
+                    </DialogActions>
+                </DialogBody>
+            </DialogSurface>
+        </Dialog>
     );
 };

--- a/webapp/src/components/shared/ReloadModal.tsx
+++ b/webapp/src/components/shared/ReloadModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Modal } from './Modal';
+import { useAppSelector } from '../../redux/app/hooks';
+import { RootState } from '../../redux/app/store';
+
+/** ReloadModal component - will reload page when user confirms. */
+export const ReloadModal: React.FC = () => {
+    const { dialog } = useAppSelector((state: RootState) => state.app);
+
+    return (
+        !!dialog && (
+            <Modal
+                open={!!dialog}
+                onConfirm={() => {
+                    window.location.reload();
+                }}
+                text={dialog.text}
+            />
+        )
+    );
+};

--- a/webapp/src/components/shared/ReloadModal.tsx
+++ b/webapp/src/components/shared/ReloadModal.tsx
@@ -3,18 +3,18 @@ import { Modal } from './Modal';
 import { useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
 
-/** ReloadModal component - will reload page when user confirms. */
+/** ReloadModal component - will reload page when user confirms. Triggered by reducer that is populated on SignalR events. */
 export const ReloadModal: React.FC = () => {
-    const { dialog } = useAppSelector((state: RootState) => state.app);
+    const { reloadDialog } = useAppSelector((state: RootState) => state.app);
 
     return (
-        !!dialog && (
+        !!reloadDialog && (
             <Modal
-                open={!!dialog}
+                open={!!reloadDialog}
                 onConfirm={() => {
                     window.location.reload();
                 }}
-                text={dialog.text}
+                text={reloadDialog.text}
             />
         )
     );

--- a/webapp/src/redux/features/app/AppState.ts
+++ b/webapp/src/redux/features/app/AppState.ts
@@ -43,7 +43,7 @@ export interface Setting {
 
 export interface AppState {
     alerts: Alert[];
-    dialog?: ReloadDialog;
+    reloadDialog?: ReloadDialog;
     activeUserInfo?: ActiveUserInfo;
     authConfig?: AuthConfig | null;
     tokenUsage: TokenUsage;

--- a/webapp/src/redux/features/app/AppState.ts
+++ b/webapp/src/redux/features/app/AppState.ts
@@ -22,11 +22,8 @@ export interface Alert {
     onRetry?: () => void;
 }
 
-export interface Dialog {
+export interface ReloadDialog {
     text: string;
-    onConfirm?: () => void;
-    onCancel?: () => void;
-    reloadOnConfirm?: boolean;
 }
 
 interface Feature {
@@ -46,7 +43,7 @@ export interface Setting {
 
 export interface AppState {
     alerts: Alert[];
-    dialog?: Dialog;
+    dialog?: ReloadDialog;
     activeUserInfo?: ActiveUserInfo;
     authConfig?: AuthConfig | null;
     tokenUsage: TokenUsage;

--- a/webapp/src/redux/features/app/AppState.ts
+++ b/webapp/src/redux/features/app/AppState.ts
@@ -22,6 +22,13 @@ export interface Alert {
     onRetry?: () => void;
 }
 
+export interface Dialog {
+    text: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+    reloadOnConfirm?: boolean;
+}
+
 interface Feature {
     enabled: boolean; // Whether to show the feature in the UX
     label: string;
@@ -39,6 +46,7 @@ export interface Setting {
 
 export interface AppState {
     alerts: Alert[];
+    dialog?: Dialog;
     activeUserInfo?: ActiveUserInfo;
     authConfig?: AuthConfig | null;
     tokenUsage: TokenUsage;

--- a/webapp/src/redux/features/app/appSlice.ts
+++ b/webapp/src/redux/features/app/appSlice.ts
@@ -5,7 +5,7 @@ import { Constants } from '../../../Constants';
 import { ServiceInfo } from '../../../libs/models/ServiceInfo';
 import { TokenUsage, TokenUsageFunctionNameMap } from '../../../libs/models/TokenUsage';
 import { getUUID } from '../../../libs/utils/HelperMethods';
-import { ActiveUserInfo, Alert, AppState, Dialog, FeatureKeys, initialState } from './AppState';
+import { ActiveUserInfo, Alert, AppState, ReloadDialog, FeatureKeys, initialState } from './AppState';
 /**
  * Modified to support specialization.
  */
@@ -40,10 +40,10 @@ export const appSlice = createSlice({
                 state.alerts.splice(index, 1);
             }
         },
-        addDialog: (state: AppState, action: PayloadAction<Dialog>) => {
+        addReloadDialog: (state: AppState, action: PayloadAction<ReloadDialog>) => {
             state.dialog = action.payload;
         },
-        removeDialog: (state: AppState) => {
+        removeReloadDialog: (state: AppState) => {
             state.dialog = undefined;
         },
         updateActiveUserInfo: (state: AppState, action: PayloadAction<Partial<ActiveUserInfo>>) => {
@@ -113,8 +113,8 @@ export const appSlice = createSlice({
 
 export const {
     addAlert,
-    addDialog,
-    removeDialog,
+    addReloadDialog,
+    removeReloadDialog,
     removeAlert,
     setAlerts,
     updateActiveUserInfo,

--- a/webapp/src/redux/features/app/appSlice.ts
+++ b/webapp/src/redux/features/app/appSlice.ts
@@ -5,7 +5,7 @@ import { Constants } from '../../../Constants';
 import { ServiceInfo } from '../../../libs/models/ServiceInfo';
 import { TokenUsage, TokenUsageFunctionNameMap } from '../../../libs/models/TokenUsage';
 import { getUUID } from '../../../libs/utils/HelperMethods';
-import { ActiveUserInfo, Alert, AppState, FeatureKeys, initialState } from './AppState';
+import { ActiveUserInfo, Alert, AppState, Dialog, FeatureKeys, initialState } from './AppState';
 /**
  * Modified to support specialization.
  */
@@ -39,6 +39,12 @@ export const appSlice = createSlice({
             if (index !== -1) {
                 state.alerts.splice(index, 1);
             }
+        },
+        addDialog: (state: AppState, action: PayloadAction<Dialog>) => {
+            state.dialog = action.payload;
+        },
+        removeDialog: (state: AppState) => {
+            state.dialog = undefined;
         },
         updateActiveUserInfo: (state: AppState, action: PayloadAction<Partial<ActiveUserInfo>>) => {
             state.activeUserInfo = Object.assign({}, state.activeUserInfo, action.payload);
@@ -107,6 +113,8 @@ export const appSlice = createSlice({
 
 export const {
     addAlert,
+    addDialog,
+    removeDialog,
     removeAlert,
     setAlerts,
     updateActiveUserInfo,

--- a/webapp/src/redux/features/app/appSlice.ts
+++ b/webapp/src/redux/features/app/appSlice.ts
@@ -174,5 +174,5 @@ const updateConnectionStatus = (state: AppState, statusUpdate: Alert) => {
         state.alerts.splice(connectionAlertIndex, 1);
     }
 
-    addNewAlert(state.alerts, statusUpdate);
+    addReloadDialog({ text: statusUpdate.message });
 };

--- a/webapp/src/redux/features/app/appSlice.ts
+++ b/webapp/src/redux/features/app/appSlice.ts
@@ -41,10 +41,10 @@ export const appSlice = createSlice({
             }
         },
         addReloadDialog: (state: AppState, action: PayloadAction<ReloadDialog>) => {
-            state.dialog = action.payload;
+            state.reloadDialog = action.payload;
         },
         removeReloadDialog: (state: AppState) => {
-            state.dialog = undefined;
+            state.reloadDialog = undefined;
         },
         updateActiveUserInfo: (state: AppState, action: PayloadAction<Partial<ActiveUserInfo>>) => {
             state.activeUserInfo = Object.assign({}, state.activeUserInfo, action.payload);

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -10,7 +10,7 @@ import { IChatUser } from '../../../libs/models/ChatUser';
 import { PlanState } from '../../../libs/models/Plan';
 import { BackendServiceUrl } from '../../../libs/services/BaseService';
 import { StoreMiddlewareAPI } from '../../app/store';
-import { addAlert, setMaintenance, addDialog } from '../app/appSlice';
+import { addAlert, setMaintenance, addReloadDialog } from '../app/appSlice';
 import { ChatState } from '../conversations/ChatState';
 import { UpdatePluginStatePayload } from '../conversations/ConversationsState';
 
@@ -94,9 +94,8 @@ const registerCommonSignalConnectionEvents = (hubConnection: signalR.HubConnecti
         if (hubConnection.state === signalR.HubConnectionState.Connected) {
             const message = 'Connection reestablished. Please refresh the page to ensure you have the latest data.';
             store.dispatch(
-                addDialog({
+                addReloadDialog({
                     text: message,
-                    reloadOnConfirm: true,
                 }),
             );
             console.log(message + ` Connected with connectionId ${connectionId}`);

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -10,7 +10,7 @@ import { IChatUser } from '../../../libs/models/ChatUser';
 import { PlanState } from '../../../libs/models/Plan';
 import { BackendServiceUrl } from '../../../libs/services/BaseService';
 import { StoreMiddlewareAPI } from '../../app/store';
-import { addAlert, setMaintenance } from '../app/appSlice';
+import { addAlert, setMaintenance, addDialog } from '../app/appSlice';
 import { ChatState } from '../conversations/ChatState';
 import { UpdatePluginStatePayload } from '../conversations/ConversationsState';
 
@@ -93,7 +93,12 @@ const registerCommonSignalConnectionEvents = (hubConnection: signalR.HubConnecti
     hubConnection.onreconnected((connectionId = '') => {
         if (hubConnection.state === signalR.HubConnectionState.Connected) {
             const message = 'Connection reestablished. Please refresh the page to ensure you have the latest data.';
-            store.dispatch(addAlert({ message, type: AlertType.Success, id: Constants.app.CONNECTION_ALERT_ID }));
+            store.dispatch(
+                addDialog({
+                    text: message,
+                    reloadOnConfirm: true,
+                }),
+            );
             console.log(message + ` Connected with connectionId ${connectionId}`);
         }
     });


### PR DESCRIPTION
### Motivation and Context
When the app would reconnect to the WebSocket after a period of time, the data would go stale. There would be an error alert displayed for a short duration; however, if the user is tabbed out they would never see it.

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
Add a modal that tells the user it has been reconnected, and that they will need to refresh in order to ensure data has not gone stale. Clicking ok will perform a reload.

![image](https://github.com/user-attachments/assets/624da00b-edc7-4677-8d02-5443548f9f14)


<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
