### PR TITLE
Restrict user from sending concurrent messages

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -105,6 +105,17 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
     // Current chat state
     const chatState = conversations[selectedId];
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        // only submit if the user presses enter without shift and the bot is not generating a response
+        if (event.key === 'Enter' && !event.shiftKey && chatState.botResponseStatus !== 'Generating bot response') {
+            event.preventDefault();
+            handleSubmit(input);
+        } else if (event.key === 'Enter' && !event.shiftKey) {
+            // without this the text area will add a new line when pressing enter without shift key while bot is generating a response
+            event.preventDefault();
+        }
+    };
+
     React.useEffect(() => {
         // Focus on the text area when the selected conversation changes
         textAreaRef.current?.focus();
@@ -294,12 +305,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
 
                         setInput(data.value);
                     }}
-                    onKeyDown={(event) => {
-                        if (event.key === 'Enter' && !event.shiftKey) {
-                            event.preventDefault();
-                            handleSubmit(input);
-                        }
-                    }}
+                    onKeyDown={handleKeyDown}
                     onBlur={() => {
                         // User is considered not typing if the input is not  in focus
                         if (activeUserInfo) {


### PR DESCRIPTION
### Motivation and Context
Currently the user is able to send multiple messages before the bot finishes responding to the first one. This causes workflow issues. 
<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description
The changes to `onKeyDown` mimic that of chatgpt. A user may hit `Shift + Enter` to create a new line at any time; however, a user may not submit their message while the bot is generating a response.  The behaviour is now identical to that of chatgpt.com resulting in a more intuitive workflow. 

Buttons are already disabled while the bot is generating a response, but you could bypass them previously by hitting enter.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
