### PR TITLE
Defer citation formatting to frontend

### DIFF
--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -1224,20 +1224,21 @@ public class ChatPlugin
                     .Where(citation => referencedCitations.Contains(citation.SourceName))
                     .ToList();
 
-                // Replace citations with superscript numbers in the current content piece
-                var processedContentPiece = citationPattern.Replace(
-                    contentPiece.ToString(),
-                    match =>
-                    {
-                        var citationKey = match.Groups[1].Value;
-                        if (!citationIndexMap.TryGetValue(citationKey, out int value))
-                        {
-                            value = citationIndexMap.Count + 1;
-                            citationIndexMap[citationKey] = value;
-                        }
-                        return $"^{value}^";
-                    }
-                );
+                // This can corrupt the way the bot formats citations in its answers! Deferring this formatting to the frontend.
+                // var processedContentPiece = citationPattern.Replace(
+                //     contentPiece.ToString(),
+                //     match =>
+                //     {
+                //         var citationKey = match.Groups[1].Value;
+                //         if (!citationIndexMap.TryGetValue(citationKey, out int value))
+                //         {
+                //             value = citationIndexMap.Count + 1;
+                //             citationIndexMap[citationKey] = value;
+                //         }
+                //         return $"^{value}^";
+                //     }
+                // );
+                var processedContentPiece = contentPiece;
 
                 // Update the message content and citations on the client
                 chatMessage.Content += processedContentPiece;

--- a/webapp/src/components/chat/chat-history/ChatHistoryTextContent.tsx
+++ b/webapp/src/components/chat/chat-history/ChatHistoryTextContent.tsx
@@ -22,7 +22,9 @@ interface ChatHistoryTextContentProps {
 export const ChatHistoryTextContent: React.FC<ChatHistoryTextContentProps> = ({ message }) => {
     const classes = useClasses();
     const content = utils.replaceMathBracketsWithDollarSigns(
-        utils.replaceCitationLinksWithIndices(utils.formatChatTextContent(message.content), message),
+        utils.replaceBracketStyleCitationsWithCaret(
+            utils.replaceCitationLinksWithIndices(utils.formatChatTextContent(message.content), message),
+        ),
     );
 
     return (

--- a/webapp/src/components/utils/TextUtils.tsx
+++ b/webapp/src/components/utils/TextUtils.tsx
@@ -93,6 +93,18 @@ export function replaceCitationLinksWithIndices(formattedMessageContent: string,
     return formattedMessageContent;
 }
 
+export function replaceBracketStyleCitationsWithCaret(formattedMessageContent: string) {
+    const docX = /\[(doc\d+)\](,)?/gm;
+    const citationIndexMap: Record<string, number> = {};
+    return formattedMessageContent.replace(docX, (_match, p1: string) => {
+        if (!citationIndexMap[p1]) {
+            const value = Object.values(citationIndexMap).length + 1;
+            citationIndexMap[p1] = value;
+        }
+        return `^${citationIndexMap[p1]}^`;
+    });
+}
+
 /**
  * Will first escape all dollar signs present in the original string.
  * Then, replace every occurrence of block style MathJax delimiters \[ and \] with $$ and $$


### PR DESCRIPTION


### Motivation and Context
This is to address a bug where the citation list component at the bottom of a chat response appeared to be lost during longer chat sessions, even when the generated text appeared to contain citation superscript.

### Description
Commented out code in ChatPlugin that was replacing the citation text markers in the response and made this happen as part of the frontend's response formatting instead.

It seems that when the backend does this replacement, the formatted answer is somehow being stored and this may eventually affect the way the bot responds in subsequent messages (ie. responding with ^1^ instead of [doc1]). Allowing the frontend to do this replace instead seems to make the bot respond consistently. Note that this appears to be in line with the way this is handled by the Chat Playground in Azure portal, so I think this is the appropriate solution.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
