### PR TITLE
Fix choppy display of existing chats

### DIFF
--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -76,7 +76,7 @@ export const ChatRoom: React.FC = () => {
     };
     const { specializations } = useAppSelector((state: RootState) => state.admin);
 
-    const [showSpecialization, setShowSpecialization] = useState(true);
+    const [showSpecialization, setShowSpecialization] = useState(false);
     const [showSuggestions, setShowSuggestions] = useState(true);
 
     React.useEffect(() => {


### PR DESCRIPTION
### Motivation and Context
Currently when you load the app and have an existing conversation created, the app will quickly display the specialization selections, and then disappear after the flag is correctly set. This is because we had `showSpecializations` defaulted to `true` which would cause it to display before it was set correctly. 

To see this behaviour:
1. Load dev
2. If you do not have an existing convo, create one
3. Refresh while having an existing convo selected
4. Watch the specialization options flicker on the screen

<!-- Thank you for your contribution to the chat-copilot repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  5. What problem does it solve?
  6. What scenario does it contribute to?
  7. If it fixes an open issue, please link to the issue here.
-->

### Description
Flag is set to false by default and the `useEffect` will set the flag accordingly on page load.

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
