### PR TITLE
Fix suggestions errors

### DIFF
--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -229,7 +229,8 @@ public class ChatPlugin
         string userId,
         KernelArguments chatContext,
         CopilotChatMessage userMessage,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        bool silent = false
     )
     {
         // Render system instruction components and create the meta-prompt template
@@ -292,7 +293,6 @@ public class ChatPlugin
             .GetContextMessagesTokenCount(metaPrompt)
             .ToString(CultureInfo.CurrentCulture);
 
-        // Stream the response to the client
         var botPrompt = new BotResponsePrompt(
             systemInstructions,
             audience,
@@ -302,13 +302,24 @@ public class ChatPlugin
             metaPrompt
         );
 
-        return await this.StreamBotResponseAsync(
-            chatId,
-            userId,
-            chatContext,
-            botPrompt,
-            citationMap.Values.AsEnumerable(),
-            cancellationToken
+        return await (
+            silent
+                ? this.OneOffBotResponseAsync(
+                    chatId,
+                    userId,
+                    chatContext,
+                    botPrompt,
+                    citationMap.Values.AsEnumerable(),
+                    cancellationToken
+                )
+                : this.StreamBotResponseAsync(
+                    chatId,
+                    userId,
+                    chatContext,
+                    botPrompt,
+                    citationMap.Values.AsEnumerable(),
+                    cancellationToken
+                )
         );
     }
 
@@ -332,19 +343,14 @@ public class ChatPlugin
         // Set the system description in the prompt options
         await this.SetSystemDescriptionAsync(chatId, cancellationToken);
 
-        var newUserMessage = new CopilotChatMessage(
+        this._logger.LogInformation("Saving suggestions user message to chat history.");
+        var suggestionsMessage = await this.SaveNewMessageAsync(
+            message,
             userId,
             userName,
             chatId,
-            message,
-            string.Empty,
-            null,
-            CopilotChatMessage.AuthorRoles.User,
-            // Default to a standard message if the `type` is not recognized
-            Enum.TryParse(messageType, out CopilotChatMessage.ChatMessageType typeAsEnum)
-            && Enum.IsDefined(typeof(CopilotChatMessage.ChatMessageType), typeAsEnum)
-                ? typeAsEnum
-                : CopilotChatMessage.ChatMessageType.Message
+            messageType,
+            cancellationToken
         );
 
         // Clone the context to avoid modifying the original context variables.
@@ -352,13 +358,14 @@ public class ChatPlugin
         chatContext["knowledgeCutoff"] = this._promptOptions.KnowledgeCutoffDate;
 
         this._logger.LogInformation("Getting chat response! Silent version.");
-        // Directly get the chat response without extracting user intent
-        CopilotChatMessage chatMessage = await this.GetChatResponseSilentAsync(
+
+        CopilotChatMessage chatMessage = await this.GetChatResponseAsync(
             chatId,
             userId,
             chatContext,
-            newUserMessage,
-            cancellationToken
+            suggestionsMessage,
+            cancellationToken,
+            silent: true
         );
         context["input"] = chatMessage.Content;
 
@@ -369,9 +376,12 @@ public class ChatPlugin
         else
         {
             this._logger.LogWarning(
-                "ChatPlugin.ChatAsync token usage unknown. Ensure token management has been implemented correctly."
+                "ChatPlugin.ChatSilentAsync token usage unknown. Ensure token management has been implemented correctly."
             );
         }
+
+        this._logger.LogInformation("Delete suggestions user message from chat history.");
+        await this._chatMessageRepository.DeleteAsync(suggestionsMessage);
 
         return context;
     }
@@ -600,17 +610,15 @@ public class ChatPlugin
         CancellationToken cancellationToken
     )
     {
-        string speckey = (string)chatContext[this._qAzureOpenAIChatExtension.ContextKey]!;
-
         var chatCompletion = this._kernel.GetRequiredService<IChatCompletionService>();
         var stream = await chatCompletion.GetChatMessageContentAsync(
             promptView.MetaPromptTemplate,
-            this.CreateChatRequestSettings(),
+            null,
             this._kernel,
             cancellationToken
         );
         // Return the constructed message without saving to chat history.
-        var chatmessage = new CopilotChatMessage(
+        var chatMessage = new CopilotChatMessage(
             userId,
             "Bot",
             chatId,
@@ -618,7 +626,7 @@ public class ChatPlugin
             promptView.MetaPromptTemplate.ToString(),
             citations
         );
-        return chatmessage;
+        return chatMessage;
     }
 
     /// <summary>

--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -613,7 +613,7 @@ public class ChatPlugin
         var chatCompletion = this._kernel.GetRequiredService<IChatCompletionService>();
         var stream = await chatCompletion.GetChatMessageContentAsync(
             promptView.MetaPromptTemplate,
-            null,
+            null, // null because we currently do not use specialization data to generate suggestions.
             this._kernel,
             cancellationToken
         );


### PR DESCRIPTION
### Description

This PR fixes the errors with suggestions.

ChatSilentAsync now uses the same workflow as the refactored ChatAsync, except there is now a flag which determines whether to stream the response to the client or to simply return the message, which is what we want for suggestions. Once the suggestions message is returned, it is deleted from the chat history so it won't show up when the page is refreshed. 

There is now a bunch of unused code in ChatPlugin.cs. I created [Task](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:pcPrzqFEXxjdzq0q_1KAcdx2-z7xyifrvTu1NfyDXBM1@thread.tacv2_p_igX6lyIvYUC5XldjHm2UF2QABb-e_h_1718816433890?tenantId=8d981e31-8642-4ee1-aa96-3f75071482c2&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fv1%2Fplan%2FigX6lyIvYUC5XldjHm2UF2QABb-e%2Ftask%2FnB4xRBehPEaQ_OQdl3ulbGQAEJPB%22%2C%22channelId%22%3A%2219%3ApcPrzqFEXxjdzq0q_1KAcdx2-z7xyifrvTu1NfyDXBM1%40thread.tacv2%22%7D) to remove it.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile: