### PR TITLE
Configure completion token limit per deployment

### DIFF
--- a/helm/config/dev/appsettings.Development.json
+++ b/helm/config/dev/appsettings.Development.json
@@ -72,10 +72,7 @@
         "Name": "ncus-qsl-openai-poc",
         "Endpoint": "https://ncus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://ncus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o",
-          "gpt-4"
-        ],
+        "ChatCompletionDeployments": [{ "Name": "gpt-4o", "CompletionTokenLimit": 16384  }, { "Name": "gpt-4", "CompletionTokenLimit": 8192  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]
@@ -84,9 +81,7 @@
         "Name": "eus-qsl-openai-poc",
         "Endpoint": "https://eus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://eus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o-mini"
-        ],
+        "ChatCompletionDeployments": [ { "Name": "gpt-4o-mini", "CompletionTokenLimit": 16384  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]

--- a/helm/config/prod/appsettings.Production.json
+++ b/helm/config/prod/appsettings.Production.json
@@ -62,10 +62,7 @@
         "Name": "ncus-qsl-openai-poc",
         "Endpoint": "https://ncus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://ncus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o",
-          "gpt-4"
-        ],
+        "ChatCompletionDeployments": [{ "Name": "gpt-4o", "CompletionTokenLimit": 16384  }, { "Name": "gpt-4", "CompletionTokenLimit": 8192  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]
@@ -74,9 +71,7 @@
         "Name": "eus-qsl-openai-poc",
         "Endpoint": "https://eus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://eus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o-mini"
-        ],
+        "ChatCompletionDeployments": [ { "Name": "gpt-4o-mini", "CompletionTokenLimit": 16384  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]

--- a/helm/config/test/appsettings.Test.json
+++ b/helm/config/test/appsettings.Test.json
@@ -62,10 +62,7 @@
         "Name": "ncus-qsl-openai-poc",
         "Endpoint": "https://ncus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://ncus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o",
-          "gpt-4"
-        ],
+        "ChatCompletionDeployments": [{ "Name": "gpt-4o", "CompletionTokenLimit": 16384  }, { "Name": "gpt-4", "CompletionTokenLimit": 8192  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]
@@ -74,9 +71,7 @@
         "Name": "eus-qsl-openai-poc",
         "Endpoint": "https://eus-qsl-openai-poc.openai.azure.com/",
         "EmbeddingEndpoint": "https://eus-qsl-openai-poc.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings?api-version=2023-05-15",
-        "ChatCompletionDeployments": [
-          "gpt-4o-mini"
-        ],
+        "ChatCompletionDeployments": [ { "Name": "gpt-4o-mini", "CompletionTokenLimit": 16384  } ],
         "EmbeddingDeployments": [
           "text-embedding-ada-002"
         ]

--- a/webapi/Controllers/SpecializationController.cs
+++ b/webapi/Controllers/SpecializationController.cs
@@ -99,7 +99,7 @@ public class SpecializationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public List<string> GetAllChatCompletionDeployments()
     {
-        return this._qAzureOpenAIChatExtension.GetAllChatCompletionDeployments();
+        return this._qAzureOpenAIChatExtension.GetAllChatCompletionDeployments().Select(deploy => deploy.Name).ToList();
     }
 
     /// <summary>

--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -708,7 +708,7 @@ public class ChatPlugin
         // Clone the context to avoid modifying the original context variables
         KernelArguments audienceContext = new(context);
         int historyTokenBudget =
-            this._promptOptions.CompletionTokenLimit
+            this.GetCompletionTokenLimit()
             - this.GetResponseTokenLimit()
             - TokenUtils.TokenCount(
                 string.Join(
@@ -753,7 +753,7 @@ public class ChatPlugin
         KernelArguments intentContext = new(context);
 
         int tokenBudget =
-            this._promptOptions.CompletionTokenLimit
+            this.GetCompletionTokenLimit()
             - this.GetResponseTokenLimit()
             - TokenUtils.TokenCount(
                 string.Join(
@@ -1023,6 +1023,15 @@ public class ChatPlugin
     }
 
     /// <summary>
+    /// Calculate the maximum number of tokens usable to generate the response.
+    /// </summary>
+    private int GetCompletionTokenLimit()
+    {
+        var deploymentConnection = this._qAzureOpenAIChatExtension.GetAllChatCompletionDeployments().FirstOrDefault(w => w.Name == this._qSpecialization?.Deployment);
+        return deploymentConnection == null ? this._promptOptions.CompletionTokenLimit : deploymentConnection.CompletionTokenLimit;
+    }
+
+    /// <summary>
     /// Calculate the maximum number of tokens that can be sent in a request
     /// </summary>
     private int GetMaxRequestTokenBudget()
@@ -1031,7 +1040,7 @@ public class ChatPlugin
         // "content": "Assistant is a large language model.","role": "system"
         // This burns just under 20 tokens which need to be accounted for.
         const int ExtraOpenAiMessageTokens = 20;
-        return this._promptOptions.CompletionTokenLimit // Total token limit
+        return this.GetCompletionTokenLimit() // Total token limit
             - ExtraOpenAiMessageTokens
             // Token count reserved for model to generate a response
             - this.GetResponseTokenLimit()

--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -1027,8 +1027,12 @@ public class ChatPlugin
     /// </summary>
     private int GetCompletionTokenLimit()
     {
-        var deploymentConnection = this._qAzureOpenAIChatExtension.GetAllChatCompletionDeployments().FirstOrDefault(w => w.Name == this._qSpecialization?.Deployment);
-        return deploymentConnection == null ? this._promptOptions.CompletionTokenLimit : deploymentConnection.CompletionTokenLimit;
+        var deploymentConnection = this
+            ._qAzureOpenAIChatExtension.GetAllChatCompletionDeployments()
+            .FirstOrDefault(w => w.Name == this._qSpecialization?.Deployment);
+        return deploymentConnection == null
+            ? this._promptOptions.CompletionTokenLimit
+            : deploymentConnection.CompletionTokenLimit;
     }
 
     /// <summary>

--- a/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
+++ b/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
@@ -192,16 +192,16 @@ public class QAzureOpenAIChatExtension
     /// <summary>
     /// Retrieve all chat completion deployments from the available OpenAI deployment connections.
     /// </summary>
-    public List<string> GetAllChatCompletionDeployments()
+    public List<QAzureOpenAIChatOptions.ChatCompletionDeployment> GetAllChatCompletionDeployments()
     {
-        var chatCompletionDeployments = new List<string>();
+        var chatCompletionDeployments = new List<QAzureOpenAIChatOptions.ChatCompletionDeployment>();
         foreach (
             QAzureOpenAIChatOptions.OpenAIDeploymentConnection connection in this._qAzureOpenAIChatOptions.OpenAIDeploymentConnections
         )
         {
             foreach (var deployment in connection.ChatCompletionDeployments)
             {
-                chatCompletionDeployments.Add($"{deployment}");
+                chatCompletionDeployments.Add(deployment);
             }
         }
         return chatCompletionDeployments;

--- a/webapi/Plugins/Chat/Ext/QAzureOpenAIChatOptions.cs
+++ b/webapi/Plugins/Chat/Ext/QAzureOpenAIChatOptions.cs
@@ -40,12 +40,18 @@ public class QAzureOpenAIChatOptions
     [Required]
     public BlobStorageOption BlobStorage { get; set; } = new BlobStorageOption();
 
+    public class ChatCompletionDeployment
+    {
+        public string Name { get; set; } = string.Empty;
+        public int CompletionTokenLimit { get; set; }
+    }
+
     public class OpenAIDeploymentConnection
     {
         public string Name { get; set; } = string.Empty;
         public Uri? Endpoint { get; set; } = null;
         public string APIKey { get; set; } = string.Empty;
-        public IList<string> ChatCompletionDeployments { get; set; } = new List<string>();
+        public IList<ChatCompletionDeployment> ChatCompletionDeployments { get; set; } = new List<ChatCompletionDeployment>();
         public IList<string> EmbeddingDeployments { get; set; } = new List<string>();
     }
 

--- a/webapi/Plugins/Chat/Ext/QAzureOpenAIChatOptions.cs
+++ b/webapi/Plugins/Chat/Ext/QAzureOpenAIChatOptions.cs
@@ -51,7 +51,8 @@ public class QAzureOpenAIChatOptions
         public string Name { get; set; } = string.Empty;
         public Uri? Endpoint { get; set; } = null;
         public string APIKey { get; set; } = string.Empty;
-        public IList<ChatCompletionDeployment> ChatCompletionDeployments { get; set; } = new List<ChatCompletionDeployment>();
+        public IList<ChatCompletionDeployment> ChatCompletionDeployments { get; set; } =
+            new List<ChatCompletionDeployment>();
         public IList<string> EmbeddingDeployments { get; set; } = new List<string>();
     }
 

--- a/webapi/Services/SemanticKernelProvider.cs
+++ b/webapi/Services/SemanticKernelProvider.cs
@@ -63,11 +63,11 @@ public sealed class SemanticKernelProvider
                     {
 #pragma warning disable CA2000 // No need to dispose of HttpClient instances from IHttpClientFactory
                         builder.AddAzureOpenAIChatCompletion(
-                            deployment,
+                            deployment.Name,
                             connection.Endpoint?.ToString(),
                             connection.APIKey,
                             httpClient: httpClientFactory.CreateClient(),
-                            serviceId: deployment
+                            serviceId: deployment.Name
                         );
                     }
                 }


### PR DESCRIPTION
### Motivation and Context
The original repo assumes a setup using just a single deployment, and has this value configured accordingly. This value is not global, and should instead be defined per deployment.

### Description
Made the list of deployment connections into a list of objects so that we can give them both a name and the token limit. When computing this value, it will now try to get the value per deployment and only use the global value as a fallback.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
