### PR TITLE
Delete document dev environment bugfix

### DIFF
--- a/webapi/Controllers/DocumentController.cs
+++ b/webapi/Controllers/DocumentController.cs
@@ -166,6 +166,49 @@ public class DocumentController : ControllerBase
         return this.DocumentDeleteAsync(memoryClient, messageRelayHubContext, DocumentScopes.Chat, sourceId, chatId);
     }
 
+    private async Task<IActionResult> DocumentDeleteAsync(
+    IKernelMemory memoryClient,
+    IHubContext<MessageRelayHub> messageRelayHubContext,
+    DocumentScopes documentScope,
+    Guid sourceId,
+    Guid chatId
+)
+    {
+        var sourceIdString = sourceId.ToString();
+        var chatIdString = chatId.ToString();
+
+        // Try to find and delete the source
+        MemorySource? source = await this._sourceRepository.FindByIdAsync(sourceIdString, chatIdString);
+        if (source == null)
+        {
+            return this.NotFound($"No document memory source found for id '{sourceId}' and partition '{chatId}'");
+        }
+
+        // Attempt deletion operations
+        try
+        {
+            await Task.WhenAll(
+                this._sourceRepository.DeleteAsync(source),
+                memoryClient.DeleteDocumentAsync(sourceIdString, this._promptOptions.MemoryIndexName)
+            );
+
+            await messageRelayHubContext.Clients.All.SendAsync(
+                DocumentDeletedClientCall,
+                source.Name,
+                this._authInfo.Name
+            );
+        }
+        catch (AggregateException ex)
+        {
+            return this.StatusCode(
+                500,
+                $"An error occurred while deleting document for source id '{sourceId}': {ex.Message}"
+            );
+        }
+
+        return this.NoContent();
+    }
+
     private async Task<IActionResult> DocumentImportAsync(
         IKernelMemory memoryClient,
         IHubContext<MessageRelayHub> messageRelayHubContext,
@@ -318,49 +361,6 @@ public class DocumentController : ControllerBase
                 return false;
             }
         }
-    }
-
-    private async Task<IActionResult> DocumentDeleteAsync(
-        IKernelMemory memoryClient,
-        IHubContext<MessageRelayHub> messageRelayHubContext,
-        DocumentScopes documentScope,
-        Guid sourceId,
-        Guid chatId
-    )
-    {
-        var sourceIdString = sourceId.ToString();
-        var chatIdString = chatId.ToString();
-
-        // Try to find and delete the source
-        MemorySource? source = await this._sourceRepository.FindByIdAsync(sourceIdString, chatIdString);
-        if (source == null)
-        {
-            return this.NotFound($"No document memory source found for id '{sourceId}' and partition '{chatId}'");
-        }
-
-        // Attempt deletion operations
-        try
-        {
-            await Task.WhenAll(
-                this._sourceRepository.DeleteAsync(source),
-                memoryClient.DeleteDocumentAsync(sourceIdString, this._promptOptions.MemoryIndexName)
-            );
-
-            await messageRelayHubContext.Clients.All.SendAsync(
-                DocumentDeletedClientCall,
-                source.Name,
-                this._authInfo.Name
-            );
-        }
-        catch (AggregateException ex)
-        {
-            return this.StatusCode(
-                500,
-                $"An error occurred while deleting document for source id '{sourceId}': {ex.Message}"
-            );
-        }
-
-        return this.NoContent();
     }
 
     #region Private

--- a/webapi/Controllers/DocumentController.cs
+++ b/webapi/Controllers/DocumentController.cs
@@ -167,12 +167,12 @@ public class DocumentController : ControllerBase
     }
 
     private async Task<IActionResult> DocumentDeleteAsync(
-    IKernelMemory memoryClient,
-    IHubContext<MessageRelayHub> messageRelayHubContext,
-    DocumentScopes documentScope,
-    Guid sourceId,
-    Guid chatId
-)
+        IKernelMemory memoryClient,
+        IHubContext<MessageRelayHub> messageRelayHubContext,
+        DocumentScopes documentScope,
+        Guid sourceId,
+        Guid chatId
+    )
     {
         var sourceIdString = sourceId.ToString();
         var chatIdString = chatId.ToString();

--- a/webapi/Controllers/DocumentController.cs
+++ b/webapi/Controllers/DocumentController.cs
@@ -143,8 +143,8 @@ public class DocumentController : ControllerBase
             memoryClient,
             messageRelayHubContext,
             DocumentScopes.Global,
-            DocumentMemoryOptions.GlobalDocumentChatId,
-            sourceId
+            sourceId,
+            DocumentMemoryOptions.GlobalDocumentChatId
         );
     }
 

--- a/webapi/Controllers/DocumentController.cs
+++ b/webapi/Controllers/DocumentController.cs
@@ -128,12 +128,12 @@ public class DocumentController : ControllerBase
     /// <summary>
     /// Service API for deleting a global document.
     /// </summary>
-    [Route("documents/{sourceId:guid}/global")]
+    [Route("documents/{sourceId:guid}")]
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DocumentDeleteAsync(
+    public Task<IActionResult> DocumentDeleteGlobalAsync(
         [FromServices] IKernelMemory memoryClient,
         [FromServices] IHubContext<MessageRelayHub> messageRelayHubContext,
         [FromRoute] Guid sourceId
@@ -142,40 +142,38 @@ public class DocumentController : ControllerBase
         return this.DocumentDeleteAsync(
             memoryClient,
             messageRelayHubContext,
-            DocumentScopes.Global,
-            sourceId,
-            DocumentMemoryOptions.GlobalDocumentChatId
+            DocumentMemoryOptions.GlobalDocumentChatId,
+            sourceId
         );
     }
 
     /// <summary>
     /// Service API for deleting a document.
     /// </summary>
-    [Route("documents/{sourceId:guid}/{chatId:guid}")]
+    [Route("chats/{chatId:guid}/documents/{sourceId:guid}/")]
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public Task<IActionResult> DocumentDeleteAsync(
+    public Task<IActionResult> DocumentDeleteLocalAsync(
         [FromServices] IKernelMemory memoryClient,
         [FromServices] IHubContext<MessageRelayHub> messageRelayHubContext,
-        [FromRoute] Guid sourceId,
-        [FromRoute] Guid chatId
+        [FromRoute] Guid chatId,
+        [FromRoute] Guid sourceId
     )
     {
-        return this.DocumentDeleteAsync(memoryClient, messageRelayHubContext, DocumentScopes.Chat, sourceId, chatId);
+        return this.DocumentDeleteAsync(memoryClient, messageRelayHubContext, chatId, sourceId);
     }
 
     private async Task<IActionResult> DocumentDeleteAsync(
         IKernelMemory memoryClient,
         IHubContext<MessageRelayHub> messageRelayHubContext,
-        DocumentScopes documentScope,
-        Guid sourceId,
-        Guid chatId
+        Guid chatId,
+        Guid sourceId
     )
     {
-        var sourceIdString = sourceId.ToString();
         var chatIdString = chatId.ToString();
+        var sourceIdString = sourceId.ToString();
 
         // Try to find and delete the source
         MemorySource? source = await this._sourceRepository.FindByIdAsync(sourceIdString, chatIdString);

--- a/webapp/src/components/chat/tabs/DocumentsTab.tsx
+++ b/webapp/src/components/chat/tabs/DocumentsTab.tsx
@@ -126,8 +126,9 @@ export const DocumentsTab: React.FC = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [importingDocuments, selectedId]);
 
-    const handleDeleteResource = (sourceId: string) => {
-        void fileHandler.deleteFile(sourceId).then(() => {
+    const handleDeleteResource = (sourceId: string, chatId: string) => {
+        const deleteFromGlobal = chatId === Constants.EMPTY_GUID;
+        void fileHandler.deleteFile(sourceId, chatId, deleteFromGlobal).then(() => {
             setResources((resources) => resources.filter((resource) => resource.id !== sourceId));
         });
     };
@@ -239,7 +240,7 @@ export const DocumentsTab: React.FC = () => {
     );
 };
 
-function useTable(resources: ChatMemorySource[], onDeleteResource: (sourceId: string) => void) {
+function useTable(resources: ChatMemorySource[], onDeleteResource: (sourceId: string, chatId: string) => void) {
     const headerSortProps = (columnId: TableColumnId): TableHeaderCellProps => ({
         onClick: (e: React.MouseEvent) => {
             toggleColumnSort(e, columnId);
@@ -354,7 +355,7 @@ function useTable(resources: ChatMemorySource[], onDeleteResource: (sourceId: st
                 <TableCell key={`${item.id}-delete`}>
                     <Button
                         onClick={() => {
-                            onDeleteResource(item.id);
+                            onDeleteResource(item.id, item.chatId);
                         }}
                         icon={<DeleteRegular />}
                     ></Button>

--- a/webapp/src/libs/hooks/useFile.ts
+++ b/webapp/src/libs/hooks/useFile.ts
@@ -3,7 +3,7 @@
 import { useMsal } from '@azure/msal-react';
 import { useAppDispatch } from '../../redux/app/hooks';
 import { FeatureKeys } from '../../redux/features/app/AppState';
-import { addAlert, toggleFeatureState } from '../../redux/features/app/appSlice';
+import { addAlert, hideSpinner, showSpinner, toggleFeatureState } from '../../redux/features/app/appSlice';
 import { setImportingDocumentsToConversation } from '../../redux/features/conversations/conversationsSlice';
 import { AuthHelper } from '../auth/AuthHelper';
 import { AlertType } from '../models/AlertType';
@@ -89,6 +89,7 @@ export const useFile = () => {
 
     const deleteFile = async (sourceId: string, chatId: string, deleteFromGlobal: boolean) => {
         try {
+            dispatch(showSpinner());
             await documentImportService.deleteDocumentAsync(
                 sourceId,
                 chatId,
@@ -103,6 +104,8 @@ export const useFile = () => {
                     message,
                 }),
             );
+        } finally {
+            dispatch(hideSpinner());
         }
     };
 

--- a/webapp/src/libs/hooks/useFile.ts
+++ b/webapp/src/libs/hooks/useFile.ts
@@ -87,10 +87,12 @@ export const useFile = () => {
         }
     };
 
-    const deleteFile = async (sourceId: string) => {
+    const deleteFile = async (sourceId: string, chatId: string, deleteFromGlobal: boolean) => {
         try {
             await documentImportService.deleteDocumentAsync(
                 sourceId,
+                chatId,
+                deleteFromGlobal,
                 await AuthHelper.getSKaaSAccessToken(instance, inProgress),
             );
         } catch (error) {

--- a/webapp/src/libs/services/DocumentImportService.ts
+++ b/webapp/src/libs/services/DocumentImportService.ts
@@ -36,7 +36,7 @@ export class DocumentImportService extends BaseService {
     ) => {
         return await this.getResponseAsync(
             {
-                commandPath: deleteFromGlobal ? `documents/${sourceId}/global` : `documents/${sourceId}/${chatId}`,
+                commandPath: deleteFromGlobal ? `documents/${sourceId}` : `chats/${chatId}/documents/${sourceId}`,
                 method: 'DELETE',
             },
             accessToken,

--- a/webapp/src/libs/services/DocumentImportService.ts
+++ b/webapp/src/libs/services/DocumentImportService.ts
@@ -36,7 +36,7 @@ export class DocumentImportService extends BaseService {
     ) => {
         return await this.getResponseAsync(
             {
-                commandPath: deleteFromGlobal ? `documents/${sourceId}/${chatId}` : `documents/${sourceId}/global`,
+                commandPath: deleteFromGlobal ? `documents/${sourceId}/global` : `documents/${sourceId}/${chatId}`,
                 method: 'DELETE',
             },
             accessToken,

--- a/webapp/src/libs/services/DocumentImportService.ts
+++ b/webapp/src/libs/services/DocumentImportService.ts
@@ -28,10 +28,15 @@ export class DocumentImportService extends BaseService {
         );
     };
 
-    public deleteDocumentAsync = async (sourceId: string, accessToken: string) => {
+    public deleteDocumentAsync = async (
+        sourceId: string,
+        chatId: string,
+        deleteFromGlobal: boolean,
+        accessToken: string,
+    ) => {
         return await this.getResponseAsync(
             {
-                commandPath: `documents/${sourceId}`,
+                commandPath: deleteFromGlobal ? `documents/${sourceId}/${chatId}` : `documents/${sourceId}/global`,
                 method: 'DELETE',
             },
             accessToken,


### PR DESCRIPTION
### Description

This PR aims to fix the delete document feature not working on the dev environment. When trying to delete a document on dev, it is unable to find the document entity using the source id. 

Updated so that the entity is fetched using both source and partition id. Seems in local, when using volatile context, the partition id doesn't matter, but in CosmoDB it does. 

Since partition id differs between local and global documents, I also separated out the endpoints - one for local and one for global. This matches the pattern used for import document.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
