### PR TITLE
Cosmos db get messages optimization

### DIFF
--- a/webapi/Storage/CosmosDbContext.cs
+++ b/webapi/Storage/CosmosDbContext.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Threading.Tasks;
-using CopilotChat.WebApi.Extensions;
 using CopilotChat.WebApi.Models.Storage;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;

--- a/webapi/Storage/CosmosDbContext.cs
+++ b/webapi/Storage/CosmosDbContext.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
@@ -57,7 +58,6 @@ public class CosmosDbContext<T> : IStorageContext<T>, IDisposable
     {
         var results = new List<T>();
         var queryable = this._container.GetItemLinqQueryable<T>(true).Where(predicate);
-        Console.WriteLine($"(underlying type) BASE QUERY: {queryable.ToQueryDefinition().QueryText}");
         var iterator = queryable.ToFeedIterator();
         while (iterator.HasMoreResults)
         {
@@ -161,13 +161,13 @@ public class CosmosDbCopilotChatMessageContext : CosmosDbContext<CopilotChatMess
         {
             queryable = queryable.Take(count);
         }
-        Console.WriteLine($"BASE QUERY with {count} = {queryable.ToQueryDefinition().QueryText}");
         var iterator = queryable.ToFeedIterator();
         while (iterator.HasMoreResults)
         {
             var response = await iterator.ReadNextAsync();
             results.AddRange(response);
         }
+
         return results;
     }
 }

--- a/webapi/Storage/CosmosDbContext.cs
+++ b/webapi/Storage/CosmosDbContext.cs
@@ -156,7 +156,11 @@ public class CosmosDbCopilotChatMessageContext : CosmosDbContext<CopilotChatMess
     )
     {
         var results = new List<CopilotChatMessage>();
-        var queryable = this._container.GetItemLinqQueryable<CopilotChatMessage>(true).Where(predicate).OrderByDescending(m => m.Timestamp).Skip(skip);
+        var queryable = this
+            ._container.GetItemLinqQueryable<CopilotChatMessage>(true)
+            .Where(predicate)
+            .OrderByDescending(m => m.Timestamp)
+            .Skip(skip);
         if (count > 0)
         {
             queryable = queryable.Take(count);

--- a/webapi/Storage/FileSystemContext.cs
+++ b/webapi/Storage/FileSystemContext.cs
@@ -198,10 +198,7 @@ public class FileSystemCopilotChatMessageContext
         var compiledPredicate = predicate.Compile();
 
         // Apply the compiled predicate, ordering, and pagination
-        var result = this._entities.Values
-                         .Where(compiledPredicate)
-                         .OrderByDescending(m => m.Timestamp)
-                         .Skip(skip);
+        var result = this._entities.Values.Where(compiledPredicate).OrderByDescending(m => m.Timestamp).Skip(skip);
 
         // Apply Take only if count is greater than 0; otherwise, return all remaining results
         if (count > 0)

--- a/webapi/Storage/FileSystemContext.cs
+++ b/webapi/Storage/FileSystemContext.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading.Tasks;
-using CopilotChat.WebApi.Extensions;
 using CopilotChat.WebApi.Models.Storage;
 
 namespace CopilotChat.WebApi.Storage;

--- a/webapi/Storage/FileSystemContext.cs
+++ b/webapi/Storage/FileSystemContext.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Extensions;
@@ -30,9 +31,10 @@ public class FileSystemContext<T> : IStorageContext<T>
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate)
+    public Task<IEnumerable<T>> QueryEntitiesAsync(Expression<Func<T, bool>> predicate)
     {
-        return Task.FromResult(this._entities.Values.Where(predicate));
+        var compiledPredicate = predicate.Compile();
+        return Task.FromResult(this._entities.Values.Where(compiledPredicate));
     }
 
     /// <inheritdoc/>
@@ -188,13 +190,25 @@ public class FileSystemCopilotChatMessageContext
 
     /// <inheritdoc/>
     public Task<IEnumerable<CopilotChatMessage>> QueryEntitiesAsync(
-        Func<CopilotChatMessage, bool> predicate,
+        Expression<Func<CopilotChatMessage, bool>> predicate,
         int skip,
         int count
     )
     {
-        return Task.Run<IEnumerable<CopilotChatMessage>>(
-            () => this._entities.Values.Where(predicate).OrderByDescending(m => m.Timestamp).Skip(skip).TakeOrAll(count)
-        );
+        var compiledPredicate = predicate.Compile();
+
+        // Apply the compiled predicate, ordering, and pagination
+        var result = this._entities.Values
+                         .Where(compiledPredicate)
+                         .OrderByDescending(m => m.Timestamp)
+                         .Skip(skip);
+
+        // Apply Take only if count is greater than 0; otherwise, return all remaining results
+        if (count > 0)
+        {
+            result = result.Take(count);
+        }
+
+        return Task.FromResult(result);
     }
 }

--- a/webapi/Storage/IStorageContext.cs
+++ b/webapi/Storage/IStorageContext.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Models.Storage;
 
@@ -17,7 +18,7 @@ public interface IStorageContext<T>
     /// Query entities in the storage context.
     /// <param name="predicate">Predicate that needs to evaluate to true for a particular entryto be returned.</param>
     /// </summary>
-    Task<IEnumerable<T>> QueryEntitiesAsync(Func<T, bool> predicate);
+    Task<IEnumerable<T>> QueryEntitiesAsync(Expression<Func<T, bool>> predicate);
 
     /// <summary>
     /// Read an entity from the storage context by id.
@@ -59,7 +60,7 @@ public interface ICopilotChatMessageStorageContext : IStorageContext<CopilotChat
     /// <param name="count">The number of messages to return. -1 returns all messages.</param>
     /// <returns>A list of ChatMessages matching the given chatId sorted from most recent to oldest.</returns>
     Task<IEnumerable<CopilotChatMessage>> QueryEntitiesAsync(
-        Func<CopilotChatMessage, bool> predicate,
+        Expression<Func<CopilotChatMessage, bool>> predicate,
         int skip = 0,
         int count = -1
     );

--- a/webapi/Storage/Repository.cs
+++ b/webapi/Storage/Repository.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Models.Storage;
 
@@ -94,7 +95,7 @@ public class CopilotChatMessageRepository : Repository<CopilotChatMessage>
     /// <param name="count">The number of messages to return. -1 returns all messages.</param>
     /// <returns>A list of ChatMessages matching the given chatId sorted from most recent to oldest.</returns>
     public async Task<IEnumerable<CopilotChatMessage>> QueryEntitiesAsync(
-        Func<CopilotChatMessage, bool> predicate,
+        Expression<Func<CopilotChatMessage, bool>> predicate,
         int skip = 0,
         int count = -1
     )

--- a/webapi/Storage/VolatileContext.cs
+++ b/webapi/Storage/VolatileContext.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using CopilotChat.WebApi.Extensions;
 using CopilotChat.WebApi.Models.Storage;
 
 namespace CopilotChat.WebApi.Storage;

--- a/webapi/Storage/VolatileContext.cs
+++ b/webapi/Storage/VolatileContext.cs
@@ -117,10 +117,7 @@ public class VolatileCopilotChatMessageContext : VolatileContext<CopilotChatMess
         var compiledPredicate = predicate.Compile();
 
         // Apply the compiled predicate, ordering, and pagination
-        var result = this._entities.Values
-                         .Where(compiledPredicate)
-                         .OrderByDescending(m => m.Timestamp)
-                         .Skip(skip);
+        var result = this._entities.Values.Where(compiledPredicate).OrderByDescending(m => m.Timestamp).Skip(skip);
 
         // Apply Take only if count is greater than 0; otherwise, return all remaining results
         if (count > 0)


### PR DESCRIPTION
### Motivation and Context
It seemed like we were not following the best practices for using the Cosmos DB SDK [outlined in MS's official documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/performance-tips-dotnet-sdk-v3?tabs=trace-net-core#sdk-usage), which may be a contributing factor to querying slowness. 

### Description

Refactored the storage context implementations to expect a Expression type. This makes it possible to use a feed iterator on the return type of the LinqQueryable in the Cosmos DB implementation. 

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
