### PR TITLE
Specialization PATCH accept unset fields in request body

### DIFF
--- a/webapi/Models/Request/QSpecializationBase.cs
+++ b/webapi/Models/Request/QSpecializationBase.cs
@@ -15,37 +15,37 @@ public class QSpecializationBase
     /// Key of the specialization
     /// </summary>
     [JsonPropertyName("label")]
-    public string Label { get; set; } = string.Empty;
+    public string? Label { get; set; }
 
     /// <summary>
     /// Name of the specialization
     /// </summary>
     [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
+    public string? Name { get; set; }
 
     /// <summary>
     /// Description of the specialization
     /// </summary>
     [JsonPropertyName("description")]
-    public string Description { get; set; } = string.Empty;
+    public string? Description { get; set; }
 
     /// <summary>
     /// RoleInformation of the specialization
     /// </summary>
     [JsonPropertyName("roleInformation")]
-    public string RoleInformation { get; set; } = string.Empty;
+    public string? RoleInformation { get; set; }
 
     /// <summary>
     /// List of group memberships for the user.
     /// </summary>
     [JsonPropertyName("groupMemberships")]
-    public IList<string> GroupMemberships { get; set; } = new List<string>();
+    public IList<string>? GroupMemberships { get; set; }
 
     /// <summary>
     /// IndexName of the specialization
     /// </summary>
     [JsonPropertyName("indexName")]
-    public string? IndexName { get; set; } = string.Empty;
+    public string? IndexName { get; set; }
 
     /// <summary>
     /// Enable/Disable flag of the specialization.
@@ -57,13 +57,13 @@ public class QSpecializationBase
     /// Deployment of the specialization
     /// </summary>
     [JsonPropertyName("deployment")]
-    public string? Deployment { get; set; } = string.Empty;
+    public string? Deployment { get; set; }
 
     /// <summary>
     /// Initial chat message that should be displayed to the client for this specialization.
     /// </summary>
     [JsonPropertyName("initialChatMessage")]
-    public string InitialChatMessage { get; set; } = string.Empty;
+    public string? InitialChatMessage { get; set; }
 
     /// <summary>
     /// Restrict Result Scope of the specialization

--- a/webapi/Services/QSpecializationService.cs
+++ b/webapi/Services/QSpecializationService.cs
@@ -170,7 +170,7 @@ public class QSpecializationService : IQSpecializationService
 
         specializationToUpdate.Deployment = qSpecializationMutate.Deployment ?? specializationToUpdate.Deployment;
 
-        specializationToUpdate.IndexName = qSpecializationMutate.IndexName;
+        specializationToUpdate.IndexName = qSpecializationMutate.IndexName ?? specializationToUpdate.IndexName;
 
         specializationToUpdate.RestrictResultScope =
             qSpecializationMutate.IndexName == null


### PR DESCRIPTION


### Motivation and Context
The behavior in the PATCH endpoint (used for disabling a specialization among other things) defaults values to an empty string if they are not present in the request body. This could result in the toggle switch blanking out most fields in a specialization, since it submits only the isActive field. 

### Description
Sets fields in the model type for Specialization request to allow unset values and removes the default empty string. This allows for a true PATCH style request.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
