### PR TITLE
Fix for switching to documents tab when on a New Chat

### DIFF
--- a/webapp/src/components/chat/tabs/DocumentsTab.tsx
+++ b/webapp/src/components/chat/tabs/DocumentsTab.tsx
@@ -102,7 +102,7 @@ export const DocumentsTab: React.FC = () => {
     const globalDocumentFileRef = useRef<HTMLInputElement | null>(null);
 
     React.useEffect(() => {
-        if (!conversations[selectedId].disabled) {
+        if (!conversations[selectedId].disabled && conversations[selectedId].createdOnServer) {
             const importingResources = importingDocuments
                 ? importingDocuments.map((document, index) => {
                       return {
@@ -121,6 +121,8 @@ export const DocumentsTab: React.FC = () => {
             void chat.getChatMemorySources(selectedId).then((sources) => {
                 setResources([...importingResources, ...sources]);
             });
+        } else {
+            setResources([]);
         }
         // We don't want to have chat as one of the dependencies as it will cause infinite loop.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -169,6 +171,7 @@ export const DocumentsTab: React.FC = () => {
                                 icon={<DocumentArrowUp20Regular />}
                                 disabled={
                                     conversations[selectedId].disabled ||
+                                    !conversations[selectedId].createdOnServer ||
                                     (importingDocuments && importingDocuments.length > 0)
                                 }
                             >


### PR DESCRIPTION

### Description

Disabled auto load of a chat's document list in useEffect of documents tab when chat not created on server. Did the same for the Upload button present here.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
