### PR TITLE
Improve chat list click responsiveness and async message loading

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -12,6 +12,7 @@ import { AuthHelper } from '../../libs/auth/AuthHelper';
 import { useFile } from '../../libs/hooks';
 import { GetResponseOptions } from '../../libs/hooks/useChat';
 import { AlertType } from '../../libs/models/AlertType';
+import { BotResponseStatus } from '../../libs/models/BotResponseStatus';
 import { ChatMessageType } from '../../libs/models/ChatMessage';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
@@ -22,7 +23,6 @@ import { getErrorDetails } from '../utils/TextUtils';
 import { SpeechService } from './../../libs/services/SpeechService';
 import { updateUserIsTyping } from './../../redux/features/conversations/conversationsSlice';
 import { ChatStatus } from './ChatStatus';
-import { BotResponseStatus } from '../../libs/models/BotResponseStatus';
 
 const log = debug(Constants.debug.root).extend('chat-input');
 
@@ -298,7 +298,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     ref={textAreaRef}
                     id="chat-input"
                     resize="vertical"
-                    disabled={chatState.disabled}
+                    disabled={chatState.disabled || chatState.loadingMessages}
                     textarea={{
                         className: isDraggingOver
                             ? mergeClasses(classes.dragAndDrop, classes.textarea)
@@ -372,7 +372,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                                 onClick={() => {
                                     handleSubmit(input);
                                 }}
-                                disabled={chatState.disabled || isSpecializationDisabled()}
+                                disabled={chatState.disabled || chatState.loadingMessages || isSpecializationDisabled()}
                             />
                         )}
                     </div>

--- a/webapp/src/components/chat/ChatRoom.tsx
+++ b/webapp/src/components/chat/ChatRoom.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { makeStyles, shorthands, Spinner, Text, tokens } from '@fluentui/react-components';
 import React, { useState } from 'react';
 import { SpecializationCardList } from '../../components/specialization/SpecializationCardList';
 import { getFriendlyChatName, GetResponseOptions, useChat } from '../../libs/hooks/useChat';
@@ -31,6 +31,17 @@ const useClasses = makeStyles({
         paddingRight: tokens.spacingHorizontalM,
         display: 'flex',
         justifyContent: 'center',
+    },
+    spinner: {
+        ...shorthands.padding(tokens.spacingVerticalM),
+        paddingLeft: tokens.spacingHorizontalM,
+        paddingRight: tokens.spacingHorizontalM,
+        display: 'flex',
+        flexDirection: 'row',
+        height: '24px',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '1rem',
     },
     input: {
         display: 'flex',
@@ -172,6 +183,12 @@ export const ChatRoom: React.FC = () => {
                     <div className={classes.history}>
                         <ChatHistory messages={messages} />
                     </div>
+                </div>
+            )}
+            {conversations[selectedId].loadingMessages && (
+                <div className={classes.spinner}>
+                    <Spinner />
+                    <Text>Retrieving messages...</Text>
                 </div>
             )}
             {showSuggestions && (

--- a/webapp/src/components/chat/chat-list/ChatListItem.tsx
+++ b/webapp/src/components/chat/chat-list/ChatListItem.tsx
@@ -128,14 +128,17 @@ export const ChatListItem: FC<IChatListItemProps> = ({
                 dispatch(setChatSpecialization(foundSpecialization));
             }
         }
-        if (conversations[id].createdOnServer && conversations[id].messages.length < 1) {
+        dispatch(setSelectedConversation(id));
+        if (
+            conversations[id].createdOnServer &&
+            conversations[id].messages.length < 1 &&
+            !conversations[id].loadingMessages
+        ) {
             chat.loadChatMessagesByChatId(id).catch((e: Error) => {
                 dispatch(
                     addAlert({ message: `Could not retrieve chat messages. ${e.message}`, type: AlertType.Error }),
                 );
             });
-        } else {
-            dispatch(setSelectedConversation(id));
         }
     };
 

--- a/webapp/src/libs/hooks/useAppLoader.ts
+++ b/webapp/src/libs/hooks/useAppLoader.ts
@@ -150,9 +150,9 @@ export const useAppLoader = (): [AppState, Dispatch<SetStateAction<AppState>>] =
     const loadInitialChat = async () => {
         const firstConvo = maxBy(Object.values(conversations), (chatState) => chatState.lastUpdatedTimestamp ?? 0);
         if (firstConvo?.createdOnServer) {
+            dispatch(setSelectedConversation(firstConvo.id));
             try {
                 await chat.loadChatMessagesByChatId(firstConvo.id);
-                dispatch(setSelectedConversation(firstConvo.id));
             } catch (err) {
                 console.log((err as Error).message);
                 setAppState(AppState.ErrorLoadingChats);

--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -15,6 +15,7 @@ import {
     deleteConversation,
     editConversationLastUpdate,
     editConversationSpecialization,
+    setChatMessagesLoading,
     setConversations,
     updateBotResponseStatus,
 } from '../../redux/features/conversations/conversationsSlice';
@@ -103,6 +104,7 @@ export const useChat = () => {
             suggestions: [],
             createdOnServer: false,
             lastUpdatedTimestamp: new Date().getTime(),
+            loadingMessages: false,
         };
 
         dispatch(addConversation(newChat));
@@ -144,6 +146,7 @@ export const useChat = () => {
                     suggestions: [],
                     createdOnServer: true,
                     lastUpdatedTimestamp: new Date().getTime(),
+                    loadingMessages: false,
                 };
                 dispatch(addConversation(newChat));
                 return newChat.id;
@@ -306,6 +309,7 @@ export const useChat = () => {
                         createdOnServer: true,
                         suggestions: [],
                         lastUpdatedTimestamp: new Date(chatSession.lastUpdatedTimestamp ?? 0).getTime(),
+                        loadingMessages: false,
                     };
                 }
 
@@ -332,15 +336,19 @@ export const useChat = () => {
 
     const loadChatMessagesByChatId = async (chatId: string) => {
         const accessToken = await AuthHelper.getSKaaSAccessToken(instance, inProgress);
+        dispatch(setChatMessagesLoading({ id: chatId, isLoading: true }));
         const participantsMessagesPromises = Promise.all([
             chatService.getAllChatParticipantsAsync(chatId, accessToken),
             chatService.getChatMessagesAsync(chatId, 0, 100, accessToken),
         ]);
         const [chatUsers, chatMessages] = await participantsMessagesPromises;
-        const conversation = Object.assign({}, conversations[chatId]);
-        conversation.users = chatUsers;
-        conversation.messages = chatMessages;
-        dispatch(addConversation(conversation));
+        if (Object.keys(conversations).includes(chatId)) {
+            const conversation = Object.assign({}, conversations[chatId]);
+            conversation.users = chatUsers;
+            conversation.messages = chatMessages;
+            conversation.loadingMessages = false;
+            dispatch(addConversation(conversation));
+        }
     };
 
     const downloadBot = async (chatId: string) => {
@@ -377,6 +385,7 @@ export const useChat = () => {
                     specializationId: chatSession.specializationId,
                     createdOnServer: true,
                     suggestions: [],
+                    loadingMessages: false,
                 };
 
                 dispatch(addConversation(newChat));
@@ -498,6 +507,7 @@ export const useChat = () => {
                     specializationId: result.specializationId,
                     createdOnServer: true,
                     suggestions: [],
+                    loadingMessages: false,
                 };
 
                 dispatch(addConversation(newChat));

--- a/webapp/src/redux/features/conversations/ChatState.ts
+++ b/webapp/src/redux/features/conversations/ChatState.ts
@@ -24,4 +24,5 @@ export interface ChatState {
     specializationId?: string;
     createdOnServer: boolean; //Flag used to check whether this piece of state has been persisted to the server store yet or not
     suggestions: string[];
+    loadingMessages: boolean;
 }

--- a/webapp/src/redux/features/conversations/ConversationsState.ts
+++ b/webapp/src/redux/features/conversations/ConversationsState.ts
@@ -56,3 +56,8 @@ export interface ConversationSuggestionsChange {
     id: string;
     chatSuggestionMessage: IAskResult;
 }
+
+export interface MessageLoadingStatusChange {
+    id: string;
+    isLoading: boolean;
+}

--- a/webapp/src/redux/features/conversations/conversationsSlice.ts
+++ b/webapp/src/redux/features/conversations/conversationsSlice.ts
@@ -15,6 +15,7 @@ import {
     ConversationTitleChange,
     ConversationUpdateTimestampChange,
     initialState,
+    MessageLoadingStatusChange,
     UpdatePluginStatePayload,
 } from './ConversationsState';
 
@@ -81,7 +82,7 @@ export const conversationsSlice = createSlice({
         addConversation: (state: ConversationsState, action: PayloadAction<ChatState>) => {
             const newId = action.payload.id;
             state.conversations = { ...state.conversations, [newId]: action.payload };
-            state.selectedId = newId;
+            // state.selectedId = newId;
         },
         addUserToConversation: (
             state: ConversationsState,
@@ -239,6 +240,9 @@ export const conversationsSlice = createSlice({
         updateSuggestions: (state: ConversationsState, action: PayloadAction<ConversationSuggestionsChange>) => {
             setConversationSuggestions(state, action.payload.id, action.payload.chatSuggestionMessage);
         },
+        setChatMessagesLoading: (state: ConversationsState, action: PayloadAction<MessageLoadingStatusChange>) => {
+            state.conversations[action.payload.id].loadingMessages = action.payload.isLoading;
+        },
     },
 });
 
@@ -333,6 +337,7 @@ export const {
     updateSuggestions,
     deleteConversationHistory,
     editConversationLastUpdate,
+    setChatMessagesLoading,
 } = conversationsSlice.actions;
 
 export default conversationsSlice.reducer;


### PR DESCRIPTION


### Motivation and Context

Users were noticing that clicking between chat list items could feel laggy since the updating of these UI elements was closely tied to the state of the relevant GET request. This decouples these states a fair bit. You should now be able to freely click between chats and the messages will appear as they become available.

### Description
* Added loadingMessages boolean property to chat state which will be true while the call to retrieve messages is underway and false when it is not. 
* This allows us to show a loading spinner in the main Chat area while the messages are still loading. 
* Made selection of chatId happen before the GET request completes so the user may click around freely while the queued messages load in the background.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
