### PR TITLE
Reorder specializations backend bugfix

### DIFF
--- a/webapi/Controllers/SpecializationController.cs
+++ b/webapi/Controllers/SpecializationController.cs
@@ -70,7 +70,13 @@ public class SpecializationController : ControllerBase
 
         var specializationResponses = specializations.Select(s => new QSpecializationResponse(s));
 
-        return this.Ok(specializationResponses);
+        var orderedSpecializations = specializationResponses
+            .Select((spec, index) => (spec, index))
+            .OrderBy(x => x.spec.Order ?? x.index)
+            .Select(x => x.spec)
+            .ToList();
+
+        return this.Ok(orderedSpecializations);
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

This PR aims to address an issue where the first re-ordering of the specializations causes them to be jumbled up. 
Seems if they are not pre-ordered in the backend first, the initial order in the front end is not reflective of the actual order, so it gets jumbled up.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
