### PR TITLE
Prevent user from messaging when no specializations available

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -12,6 +12,7 @@ import { AuthHelper } from '../../libs/auth/AuthHelper';
 import { useFile } from '../../libs/hooks';
 import { GetResponseOptions } from '../../libs/hooks/useChat';
 import { AlertType } from '../../libs/models/AlertType';
+import { BotResponseStatus } from '../../libs/models/BotResponseStatus';
 import { ChatMessageType } from '../../libs/models/ChatMessage';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { RootState } from '../../redux/app/store';
@@ -22,7 +23,6 @@ import { getErrorDetails } from '../utils/TextUtils';
 import { SpeechService } from './../../libs/services/SpeechService';
 import { updateUserIsTyping } from './../../redux/features/conversations/conversationsSlice';
 import { ChatStatus } from './ChatStatus';
-import { BotResponseStatus } from '../../libs/models/BotResponseStatus';
 
 const log = debug(Constants.debug.root).extend('chat-input');
 
@@ -88,6 +88,7 @@ const useClasses = makeStyles({
 });
 
 interface ChatInputProps {
+    disabled?: boolean;
     isDraggingOver?: boolean;
     onDragLeave: React.DragEventHandler<HTMLDivElement | HTMLTextAreaElement>;
     onSubmit: (options: GetResponseOptions) => Promise<void>;
@@ -101,7 +102,8 @@ interface ChatInputProps {
  * @param {(options: GetResponseOptions) => Promise<void>} onSubmit The function to call when the user submits a message
  * @returns {*} The chat input component
  */
-export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeave, onSubmit }) => {
+export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, onDragLeave, onSubmit }) => {
+    const inputDisabled = !!disabled;
     const classes = useClasses();
     const fileHandler = useFile();
     const dispatch = useAppDispatch();
@@ -259,6 +261,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                         <Button
                             disabled={
                                 chatState.disabled ||
+                                inputDisabled ||
                                 (chatState.importingDocuments && chatState.importingDocuments.length > 0)
                             }
                             size="large"
@@ -279,7 +282,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                     ref={textAreaRef}
                     id="chat-input"
                     resize="vertical"
-                    disabled={chatState.disabled}
+                    disabled={chatState.disabled || inputDisabled}
                     textarea={{
                         className: isDraggingOver
                             ? mergeClasses(classes.dragAndDrop, classes.textarea)
@@ -353,7 +356,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ isDraggingOver, onDragLeav
                                 onClick={() => {
                                     handleSubmit(input);
                                 }}
-                                disabled={chatState.disabled}
+                                disabled={chatState.disabled || inputDisabled}
                             />
                         )}
                     </div>

--- a/webapp/src/components/specialization/SpecializationCardList.tsx
+++ b/webapp/src/components/specialization/SpecializationCardList.tsx
@@ -1,10 +1,8 @@
 import { makeStyles } from '@fluentui/react-components';
-import React, { useMemo } from 'react';
+import React from 'react';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import { ISpecialization } from '../../libs/models/Specialization';
-import { useAppSelector } from '../../redux/app/hooks';
-import { RootState } from '../../redux/app/store';
 import { SpecializationCard } from './SpecializationCard';
 
 const responsive = {
@@ -58,40 +56,21 @@ interface SpecializationProps {
  */
 export const SpecializationCardList: React.FC<SpecializationProps> = ({ specializations }) => {
     const classes = useClasses();
-    const { activeUserInfo } = useAppSelector((state: RootState) => state.app);
-
-    // Memoize the filtered specializations based on the user's group memberships
-    const filteredSpecializations = useMemo(() => {
-        const filtered = specializations.filter((_specialization) => {
-            const hasMembership =
-                activeUserInfo?.groups.some((val) => _specialization.groupMemberships.includes(val)) ?? false;
-
-            // Check if the user has membership to the specialization group and the specialization is active
-            const canViewSpecialization =
-                ((hasMembership || _specialization.groupMemberships.length === 0) && _specialization.isActive) ||
-                _specialization.id == 'general';
-
-            return canViewSpecialization ? _specialization : undefined;
-        });
-        return [...filtered].sort((a, b) => a.order - b.order);
-    }, [activeUserInfo?.groups, specializations]);
 
     return (
         <>
-            {filteredSpecializations.length > 0 ? (
+            {specializations.length > 0 ? (
                 <>
                     <h1 className={classes.innertitle}>Choose Specialization</h1>
                     <Carousel
-                        className={
-                            filteredSpecializations.length === 1 ? classes.carouselrootSingleItem : classes.carouselroot
-                        }
+                        className={specializations.length === 1 ? classes.carouselrootSingleItem : classes.carouselroot}
                         responsive={responsive}
                         showDots={true}
                         swipeable={true}
                         arrows={true}
                         dotListClass="custom-dot-list-style"
                     >
-                        {filteredSpecializations.map((_specialization, index) => (
+                        {specializations.map((_specialization, index) => (
                             <div key={index} className={classes.innercontainerclass}>
                                 <SpecializationCard key={_specialization.id} specialization={_specialization} />
                             </div>


### PR DESCRIPTION


### Motivation and Context
Users were able to select the chat input and send a message even when no specialization should be available to the user.

### Description
* Lifted specialization filtering memo up to ChatRoom component so that the result can be drilled down into child components.
* This is fed into the new disabled prop of ChatInput to grey out the input box and buttons whenever there are no specializations available due to group membership or the specializations having inActive set to false.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
