### PR TITLE
Http Context Accessor

### DIFF
--- a/webapi/Context/ContextValueAccessor.cs
+++ b/webapi/Context/ContextValueAccessor.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace CopilotChat.WebApi.Context;
+
+public class ContextValueAccessor(IHttpContextAccessor contextAccessor) : IContextValueAccessor
+{
+    public object? GetRouteValue(string key)
+    {
+        var context = contextAccessor.HttpContext;
+
+        if (context == null)
+            return null;
+
+        context.Request.RouteValues.TryGetValue(key, out var routeValue);
+
+        return routeValue;
+    }
+}

--- a/webapi/Context/ContextValueAccessor.cs
+++ b/webapi/Context/ContextValueAccessor.cs
@@ -9,7 +9,9 @@ public class ContextValueAccessor(IHttpContextAccessor contextAccessor) : IConte
         var context = contextAccessor.HttpContext;
 
         if (context == null)
+        {
             return null;
+        }
 
         context.Request.RouteValues.TryGetValue(key, out var routeValue);
 

--- a/webapi/Context/ContextValueAccessor.test.cs
+++ b/webapi/Context/ContextValueAccessor.test.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System;
+using Microsoft.AspNetCore.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using System;
 
 namespace CopilotChat.WebApi.Context;
 
@@ -9,37 +9,36 @@ namespace CopilotChat.WebApi.Context;
 public class ContextValueAccessorTest
 {
     private const string ID_KEY = "id";
-
-    Mock<IHttpContextAccessor>? mockAccessor;
-    DefaultHttpContext? context;
-    ContextValueAccessor? accessor;
-    string? id;
+    private Mock<IHttpContextAccessor>? mockAccessor;
+    private DefaultHttpContext? context;
+    private ContextValueAccessor? accessor;
+    private string? id;
 
     [TestInitialize]
     public void Setup()
     {
-        mockAccessor = new();
-        context = new();
+        this.mockAccessor = new();
+        this.context = new();
 
-        id = Guid.NewGuid().ToString();
-        context.Request.RouteValues.Add(ID_KEY, id);
-        mockAccessor.Setup(m => m.HttpContext).Returns(context);
+        this.id = Guid.NewGuid().ToString();
+        this.context.Request.RouteValues.Add(ID_KEY, this.id);
+        this.mockAccessor.Setup(m => m.HttpContext).Returns(this.context);
 
-        accessor = new(mockAccessor.Object);
+        this.accessor = new(this.mockAccessor.Object);
     }
 
     [TestMethod]
     public void GetRouteValue_ShouldRetrieveValue()
     {
-        var value = accessor!.GetRouteValue(ID_KEY);
+        var value = this.accessor!.GetRouteValue(ID_KEY);
 
-        Assert.AreEqual(id, value);
+        Assert.AreEqual(this.id, value);
     }
 
     [TestMethod]
     public void GetRouteValue_ShouldRetrieveNull()
     {
-        var value = accessor!.GetRouteValue("BardicInspiration");
+        var value = this.accessor!.GetRouteValue("BardicInspiration");
 
         Assert.AreEqual(value, null);
     }
@@ -47,10 +46,10 @@ public class ContextValueAccessorTest
     [TestMethod]
     public void GetRouteValue_ShouldRetrieveNull_WhenContextNull()
     {
-        context = null;
-        mockAccessor!.Setup(m => m.HttpContext).Returns(context);
+        this.context = null;
+        this.mockAccessor!.Setup(m => m.HttpContext).Returns(this.context);
 
-        var value = accessor!.GetRouteValue(ID_KEY);
+        var value = this.accessor!.GetRouteValue(ID_KEY);
 
         Assert.AreEqual(value, null);
     }

--- a/webapi/Context/ContextValueAccessor.test.cs
+++ b/webapi/Context/ContextValueAccessor.test.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace CopilotChat.WebApi.Context;
+
+[TestClass]
+public class ContextValueAccessorTest
+{
+    private const string ID_KEY = "id";
+
+    Mock<IHttpContextAccessor>? mockAccessor;
+    DefaultHttpContext? context;
+    ContextValueAccessor? accessor;
+    string? id;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        mockAccessor = new();
+        context = new();
+
+        id = Guid.NewGuid().ToString();
+        context.Request.RouteValues.Add(ID_KEY, id);
+        mockAccessor.Setup(m => m.HttpContext).Returns(context);
+
+        accessor = new(mockAccessor.Object);
+    }
+
+    [TestMethod]
+    public void GetRouteValue_ShouldRetrieveValue()
+    {
+        var value = accessor!.GetRouteValue(ID_KEY);
+
+        Assert.AreEqual(id, value);
+    }
+
+    [TestMethod]
+    public void GetRouteValue_ShouldRetrieveNull()
+    {
+        var value = accessor!.GetRouteValue("BardicInspiration");
+
+        Assert.AreEqual(value, null);
+    }
+
+    [TestMethod]
+    public void GetRouteValue_ShouldRetrieveNull_WhenContextNull()
+    {
+        context = null;
+        mockAccessor!.Setup(m => m.HttpContext).Returns(context);
+
+        var value = accessor!.GetRouteValue(ID_KEY);
+
+        Assert.AreEqual(value, null);
+    }
+}

--- a/webapi/Context/IContextValueAccessor.cs
+++ b/webapi/Context/IContextValueAccessor.cs
@@ -1,0 +1,6 @@
+﻿namespace CopilotChat.WebApi.Context;
+
+public interface IContextValueAccessor
+{
+    public object? GetRouteValue(string key);
+}


### PR DESCRIPTION
- feat: HttpContextAccessor

**Notes**
This proposal seeks to create a way to access `HttpContext` values in a way that will be easy to inject into a request without having to handle the whole `HttpContext` object. This can be extended in the future to handle other accessor flows.

Next step would be to inject this interface into each request.