### PR TITLE
made it so that the correct chat is selected

### DIFF
--- a/webapp/src/libs/hooks/useChat.ts
+++ b/webapp/src/libs/hooks/useChat.ts
@@ -17,6 +17,7 @@ import {
     editConversationSpecialization,
     setChatMessagesLoading,
     setConversations,
+    setSelectedConversation,
     updateBotResponseStatus,
 } from '../../redux/features/conversations/conversationsSlice';
 import { Plugin } from '../../redux/features/plugins/PluginsState';
@@ -108,6 +109,7 @@ export const useChat = () => {
         };
 
         dispatch(addConversation(newChat));
+        dispatch(setSelectedConversation(newChat.id));
         return newChat.id;
     };
 


### PR DESCRIPTION
Currently if you create a new chat, the new chat is created but the selected chat doesn't get updated so we stay in the old chat. pushed a one line fix for it

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
