### PR TITLE
Authorization injection

### DIFF
--- a/webapi/Auth/SpecializationAuthorizationHandler.cs
+++ b/webapi/Auth/SpecializationAuthorizationHandler.cs
@@ -12,18 +12,18 @@ namespace CopilotChat.WebApi.Auth;
 /// </summary>
 public class SpecializationAuthorizationHandler(
     SpecializationRepository specializationRepository,
-    ChatSessionRepository chatSessionRepository
-) : AuthorizationHandler<SpecializationRequirement, IContextValueAccessor>
+    ChatSessionRepository chatSessionRepository,
+    IContextValueAccessor contextValueAccessor
+) : AuthorizationHandler<SpecializationRequirement>
 {
     private const string GROUP_CLAIM_TYPE = "groups";
 
     protected override async Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
-        SpecializationRequirement requirement,
-        IContextValueAccessor resource
+        SpecializationRequirement requirement
     )
     {
-        var chatId = resource.GetRouteValue("chatId")?.ToString();
+        var chatId = contextValueAccessor.GetRouteValue("chatId")?.ToString();
 
         if (string.IsNullOrEmpty(chatId))
         {

--- a/webapi/Extensions/ServiceExtensions.cs
+++ b/webapi/Extensions/ServiceExtensions.cs
@@ -16,7 +16,6 @@ using CopilotChat.WebApi.Storage;
 using CopilotChat.WebApi.Utilities;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/webapi/Extensions/ServiceExtensions.cs
+++ b/webapi/Extensions/ServiceExtensions.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using CopilotChat.Shared;
 using CopilotChat.WebApi.Auth;
+using CopilotChat.WebApi.Context;
 using CopilotChat.WebApi.Models.Storage;
 using CopilotChat.WebApi.Options;
 using CopilotChat.WebApi.Plugins.Chat.Ext;
@@ -15,6 +16,7 @@ using CopilotChat.WebApi.Storage;
 using CopilotChat.WebApi.Utilities;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -172,6 +174,16 @@ public static class CopilotChatServiceExtensions
                 });
             });
         }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Add Http context accessors
+    /// </summary>
+    public static IServiceCollection AddContextAccessors(this IServiceCollection services)
+    {
+        services.AddTransient<IContextValueAccessor, ContextValueAccessor>();
 
         return services;
     }
@@ -352,6 +364,7 @@ public static class CopilotChatServiceExtensions
     {
         return services
             .AddScoped<IAuthorizationHandler, ChatParticipantAuthorizationHandler>()
+            .AddScoped<IAuthorizationHandler, SpecializationAuthorizationHandler>()
             .AddAuthorizationCore(options =>
             {
                 options.DefaultPolicy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
@@ -360,6 +373,13 @@ public static class CopilotChatServiceExtensions
                     builder =>
                     {
                         builder.RequireAuthenticatedUser().AddRequirements(new ChatParticipantRequirement());
+                    }
+                );
+                options.AddPolicy(
+                    AuthPolicyName.RequireSpecialization,
+                    builder =>
+                    {
+                        builder.RequireAuthenticatedUser().AddRequirements(new SpecializationRequirement());
                     }
                 );
             });

--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -76,6 +76,7 @@ public sealed class Program
         // Add AppInsights telemetry
         builder
             .Services.AddHttpContextAccessor()
+            .AddContextAccessors()
             .AddApplicationInsightsTelemetry(options =>
             {
                 options.ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];


### PR DESCRIPTION
- feat: inject authorization handler and dependencies
- refactor: demote context accessors from resource to constructor params

**Notes**
Refactoring the `IContextValueAccessor` here to reflect it's role in our auth handler. The `HttpContext` is not the resource being assessed for authorization, the `ClaimsPrincipal` is. `ClaimsPrincipal` is already loaded in `AuthorizationHandlerContext`.