### PR TITLE
add specialization text to top right corner of type message box

### DIFF
--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -243,13 +243,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
         <div className={classes.root}>
             {/* only display the drop zone when the user is dragging files (will block other interactions while active) */}
             {isDraggingOver && <div className={classes.dropZone} onDrop={handleDrop} />}
-            <div style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr auto',
-                alignItems: 'center',
-                margin: '0 55px',
-                minHeight: '40px'
-            }}>
+            <div
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr auto',
+                    alignItems: 'center',
+                    margin: '0 55px',
+                    minHeight: '40px',
+                }}
+            >
                 <div style={{ textAlign: 'left' }}>
                     <ChatStatus chatState={chatState} />
                 </div>

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -252,7 +252,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
             }}>
                 <div style={{ textAlign: 'left' }}>
                     <ChatStatus chatState={chatState} />
-                </div> 
+                </div>
                 <div style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
                     chatting with: {chatSpecialization?.label ?? 'general'}
                 </div>

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -109,6 +109,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
     const dispatch = useAppDispatch();
     const { instance, inProgress } = useMsal();
 
+    const { chatSpecialization } = useAppSelector((state: RootState) => state.admin);
+
     const { conversations, selectedId } = useAppSelector((state: RootState) => state.conversations);
     const { activeUserInfo } = useAppSelector((state: RootState) => state.app);
 
@@ -252,8 +254,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
                     <ChatStatus chatState={chatState} />
                 </div>
                 <div style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
-                    chatting with: Probate Law
+                    chatting with: {chatSpecialization?.label ?? 'general'}
                 </div>
+
             </div>
             <div className={classes.content}>
                 <div className={classes.controls}>

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -241,8 +241,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
         <div className={classes.root}>
             {/* only display the drop zone when the user is dragging files (will block other interactions while active) */}
             {isDraggingOver && <div className={classes.dropZone} onDrop={handleDrop} />}
-            <div className={classes.typingIndicator}>
-                <ChatStatus chatState={chatState} />
+            <div style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
+                alignItems: 'center',
+                margin: '0 55px',
+                minHeight: '40px'
+            }}>
+                <div style={{ textAlign: 'left' }}>
+                    <ChatStatus chatState={chatState} />
+                </div>
+                <div style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    chatting with: Probate Law
+                </div>
             </div>
             <div className={classes.content}>
                 <div className={classes.controls}>

--- a/webapp/src/components/chat/ChatInput.tsx
+++ b/webapp/src/components/chat/ChatInput.tsx
@@ -252,11 +252,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({ disabled, isDraggingOver, 
             }}>
                 <div style={{ textAlign: 'left' }}>
                     <ChatStatus chatState={chatState} />
-                </div>
+                </div> 
                 <div style={{ textAlign: 'right', whiteSpace: 'nowrap' }}>
                     chatting with: {chatSpecialization?.label ?? 'general'}
                 </div>
-
             </div>
             <div className={classes.content}>
                 <div className={classes.controls}>


### PR DESCRIPTION
### Motivation and Context

this is the best location to tell users what specialization they are currently talking to when sending a message. 


### Description

crearted label 'chatting with specialization' to top right of send message box 
moved that text into a box with the bot generation text and formatted to look nice. 

### Contribution Checklist

![image](https://github.com/user-attachments/assets/37d86792-6454-4987-8498-9c0005a86843)


![image](https://github.com/user-attachments/assets/50f0a671-9af4-4f0c-a472-523f379286a8)


