### PR TITLE
Limit responses to your data context bugfix

### DIFF
--- a/webapp/src/libs/services/SpecializationService.ts
+++ b/webapp/src/libs/services/SpecializationService.ts
@@ -126,7 +126,7 @@ export class SpecializationService extends BaseService {
         formData.append('order', body.order.toString());
         formData.append('isDefault', body.isDefault.toString());
         formData.append('canGenImages', body.canGenImages.toString());
-        if (body.restrictResultScope) {
+        if (body.restrictResultScope != null) {
             formData.append('restrictResultScope', body.restrictResultScope.toString());
         }
         if (body.strictness) {


### PR DESCRIPTION
### Description

This PR addresses an issue where the "Limit responses to your data context" is still enabled even when disabled on the specialization config. I originally thought this was a backend issue, but found there was a falsy check on `restrictResultScope` in the specialization form. Because of this, even though `false` is a valid value, `restrictResultScope` can only ever be `true`. I updated this to be a null check instead. It seems to be behaving as expected now, without needing any backend changes:

Disabled:
![image](https://github.com/user-attachments/assets/a72e7b39-863e-4984-b4c3-b7c6fb1a0dec)

Enabled:
![image](https://github.com/user-attachments/assets/73035f30-9c66-4790-8f27-91f02352be42)


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
