### PR TITLE
Specialization body authorization handler

### DIFF
--- a/webapi/Auth/Specializations/AuthorizationHandler.cs
+++ b/webapi/Auth/Specializations/AuthorizationHandler.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CopilotChat.WebApi.Auth.Specializations.Models;
+using CopilotChat.WebApi.Context;
 using CopilotChat.WebApi.Storage;
 using Microsoft.AspNetCore.Authorization;
 
@@ -10,7 +12,8 @@ namespace CopilotChat.WebApi.Auth.Specializations;
 /// Class implementing "authorization" that validates the user has access to a specialization.
 /// </summary>
 public class AuthorizationHandler(
-    SpecializationRepository specializationRepository
+    SpecializationRepository specializationRepository,
+    IContextBodyAccessor contextBodyAccessor
 ) : AuthorizationHandler<SpecializationRequirement>
 {
     private const string GROUP_CLAIM_TYPE = "groups";
@@ -20,8 +23,14 @@ public class AuthorizationHandler(
         SpecializationRequirement requirement
     )
     {
-        var specializationId = ""; //contextBodyAccessor.ReadBody<>();
-        var specialization = await specializationRepository.GetSpecializationAsync(specializationId);
+        var specializationBody = await contextBodyAccessor.ReadBody<SpecializationBody>();
+
+        if (specializationBody == null || string.IsNullOrEmpty(specializationBody.SpecializationId))
+        {
+            return;
+        }
+
+        var specialization = await specializationRepository.GetSpecializationAsync(specializationBody.SpecializationId);
 
         if (specialization == null)
         {

--- a/webapi/Auth/Specializations/AuthorizationHandler.cs
+++ b/webapi/Auth/Specializations/AuthorizationHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CopilotChat.WebApi.Storage;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CopilotChat.WebApi.Auth.Specializations;
+
+/// <summary>
+/// Class implementing "authorization" that validates the user has access to a specialization.
+/// </summary>
+public class AuthorizationHandler(
+    SpecializationRepository specializationRepository
+) : AuthorizationHandler<SpecializationRequirement>
+{
+    private const string GROUP_CLAIM_TYPE = "groups";
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        SpecializationRequirement requirement
+    )
+    {
+        var specializationId = ""; //contextBodyAccessor.ReadBody<>();
+        var specialization = await specializationRepository.GetSpecializationAsync(specializationId);
+
+        if (specialization == null)
+        {
+            return;
+        }
+
+        var specializationIds = new HashSet<string>(specialization.GroupMemberships);
+
+        var user = context.User;
+        var groupClaims = user.Claims.Where(claim => claim.Type == GROUP_CLAIM_TYPE);
+        var groupIds = new HashSet<string>(groupClaims.Select(claim => claim.Value));
+
+        if (groupIds.Overlaps(specializationIds))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/webapi/Auth/Specializations/AuthorizationHandler.test.cs
+++ b/webapi/Auth/Specializations/AuthorizationHandler.test.cs
@@ -2,8 +2,8 @@
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Auth.Specializations.Models;
 using CopilotChat.WebApi.Context;
-using CopilotChat.WebApi.Storage;
 using CopilotChat.WebApi.Models.Storage;
+using CopilotChat.WebApi.Storage;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -27,13 +27,15 @@ public class AuthorizationHandlerTest
         var specialization = new Specialization() { GroupMemberships = new[] { GROUP_ID } };
 
         this.specializationContext = new();
-        this.specializationContext.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult(specialization));
+        this.specializationContext.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID))
+            .Returns(Task.FromResult(specialization));
 
         this.contextBodyAccessor = new();
-        this.contextBodyAccessor.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(specializationBody));
+        this.contextBodyAccessor.Setup(m => m.ReadBody<SpecializationBody>())
+            .Returns(Task.FromResult<SpecializationBody?>(specializationBody));
 
         this.handler = new(
-            new Mock<SpecializationRepository>(specializationContext.Object).Object,
+            new Mock<SpecializationRepository>(this.specializationContext.Object).Object,
             this.contextBodyAccessor.Object
         );
 
@@ -59,46 +61,50 @@ public class AuthorizationHandlerTest
     }
 
     [TestMethod]
-    public async Task NullContextBody_Should_NotSuccees()
+    public async Task NullContextBody_Should_NotSucceed()
     {
-        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(null));
+        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>())
+            .Returns(Task.FromResult<SpecializationBody?>(null));
 
-        await this.handler!.HandleAsync(context!);
+        await this.handler!.HandleAsync(this.context!);
 
-        Assert.IsFalse(context!.HasSucceeded);
+        Assert.IsFalse(this.context!.HasSucceeded);
     }
 
     [TestMethod]
     [DataRow(null)]
     [DataRow("")]
-    public async Task NullSpecializationId_Should_NotSuccees(string? specializationId)
+    public async Task NullSpecializationId_Should_NotSucceed(string? specializationId)
     {
         var specializationBody = new SpecializationBody() { SpecializationId = specializationId };
-        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(specializationBody));
+        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>())
+            .Returns(Task.FromResult<SpecializationBody?>(specializationBody));
 
-        await this.handler!.HandleAsync(context!);
+        await this.handler!.HandleAsync(this.context!);
 
-        Assert.IsFalse(context!.HasSucceeded);
+        Assert.IsFalse(this.context!.HasSucceeded);
     }
 
     [TestMethod]
     public async Task NullSpecialization_Should_NotSucceed()
     {
-        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult((Specialization?)null));
+        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID))
+            .Returns(Task.FromResult((Specialization?)null));
 
-        await this.handler!.HandleAsync(context!);
+        await this.handler!.HandleAsync(this.context!);
 
-        Assert.IsFalse(context!.HasSucceeded);
+        Assert.IsFalse(this.context!.HasSucceeded);
     }
 
     [TestMethod]
     public async Task SpecializationWithoutGroupMembership_Should_NotSucceed()
     {
         var specialization = new Specialization();
-        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult(specialization));
+        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID))
+            .Returns(Task.FromResult(specialization));
 
-        await this.handler!.HandleAsync(context!);
+        await this.handler!.HandleAsync(this.context!);
 
-        Assert.IsFalse(context!.HasSucceeded);
+        Assert.IsFalse(this.context!.HasSucceeded);
     }
 }

--- a/webapi/Auth/Specializations/AuthorizationHandler.test.cs
+++ b/webapi/Auth/Specializations/AuthorizationHandler.test.cs
@@ -1,0 +1,104 @@
+﻿using System.Security.Claims;
+using System.Threading.Tasks;
+using CopilotChat.WebApi.Auth.Specializations.Models;
+using CopilotChat.WebApi.Context;
+using CopilotChat.WebApi.Storage;
+using CopilotChat.WebApi.Models.Storage;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace CopilotChat.WebApi.Auth.Specializations;
+
+[TestClass]
+public class AuthorizationHandlerTest
+{
+    private const string SPECIALIZATION_ID = "ce2a1f91-09a2-41c0-9017-f0fc88c588a2";
+    private const string GROUP_ID = "7d5a7972-9d8f-48b1-9248-fdb38967a427";
+    private AuthorizationHandler? handler;
+    private AuthorizationHandlerContext? context;
+    private Mock<IStorageContext<Specialization>>? specializationContext;
+    private Mock<IContextBodyAccessor>? contextBodyAccessor;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var specializationBody = new SpecializationBody() { SpecializationId = SPECIALIZATION_ID };
+        var specialization = new Specialization() { GroupMemberships = new[] { GROUP_ID } };
+
+        this.specializationContext = new();
+        this.specializationContext.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult(specialization));
+
+        this.contextBodyAccessor = new();
+        this.contextBodyAccessor.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(specializationBody));
+
+        this.handler = new(
+            new Mock<SpecializationRepository>(specializationContext.Object).Object,
+            this.contextBodyAccessor.Object
+        );
+
+        this.context = AuthorizationTestContext.BuildAuthorizationContext(new[] { new Claim("groups", GROUP_ID) });
+    }
+
+    [TestMethod]
+    public async Task UserWithGroupMembership_Should_Succeed()
+    {
+        await this.handler!.HandleAsync(this.context!);
+
+        Assert.IsTrue(this.context!.HasSucceeded);
+    }
+
+    [TestMethod]
+    public async Task UserWithoutGroupMembership_Should_NotSucceed()
+    {
+        var context = AuthorizationTestContext.BuildAuthorizationContext(new Claim[0]);
+
+        await this.handler!.HandleAsync(context);
+
+        Assert.IsFalse(context.HasSucceeded);
+    }
+
+    [TestMethod]
+    public async Task NullContextBody_Should_NotSuccees()
+    {
+        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(null));
+
+        await this.handler!.HandleAsync(context!);
+
+        Assert.IsFalse(context!.HasSucceeded);
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    public async Task NullSpecializationId_Should_NotSuccees(string? specializationId)
+    {
+        var specializationBody = new SpecializationBody() { SpecializationId = specializationId };
+        this.contextBodyAccessor!.Setup(m => m.ReadBody<SpecializationBody>()).Returns(Task.FromResult<SpecializationBody?>(specializationBody));
+
+        await this.handler!.HandleAsync(context!);
+
+        Assert.IsFalse(context!.HasSucceeded);
+    }
+
+    [TestMethod]
+    public async Task NullSpecialization_Should_NotSucceed()
+    {
+        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult((Specialization?)null));
+
+        await this.handler!.HandleAsync(context!);
+
+        Assert.IsFalse(context!.HasSucceeded);
+    }
+
+    [TestMethod]
+    public async Task SpecializationWithoutGroupMembership_Should_NotSucceed()
+    {
+        var specialization = new Specialization();
+        this.specializationContext!.Setup(m => m.ReadAsync(SPECIALIZATION_ID, SPECIALIZATION_ID)).Returns(Task.FromResult(specialization));
+
+        await this.handler!.HandleAsync(context!);
+
+        Assert.IsFalse(context!.HasSucceeded);
+    }
+}

--- a/webapi/Auth/Specializations/AuthorizationTestContext.cs
+++ b/webapi/Auth/Specializations/AuthorizationTestContext.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+
+namespace CopilotChat.WebApi.Auth.Specializations;
+
+public static class AuthorizationTestContext
+{
+    public static AuthorizationHandlerContext BuildAuthorizationContext(IEnumerable<Claim> claims)
+    {
+        var requirements = new[] { new SpecializationRequirement() };
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "auth"));
+
+        return new(requirements, user, null);
+    }
+}

--- a/webapi/Auth/Specializations/LinkedToChatAuthorizationHandler.test.cs
+++ b/webapi/Auth/Specializations/LinkedToChatAuthorizationHandler.test.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Context;
 using CopilotChat.WebApi.Models.Storage;
@@ -23,15 +22,6 @@ public class LinkedToChatAuthorizationHandlerTest
     private Mock<IStorageContext<ChatSession>>? chatSessionContext;
     private Mock<IStorageContext<Specialization>>? specializationContext;
 
-    private AuthorizationHandlerContext BuildAuthorizationContext(IEnumerable<Claim> claims)
-    {
-        var requirements = new[] { new SpecializationRequirement() };
-
-        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "auth"));
-
-        return new(requirements, user, null);
-    }
-
     [TestInitialize]
     public void Setup()
     {
@@ -54,7 +44,7 @@ public class LinkedToChatAuthorizationHandlerTest
             this.httpContextAccessor.Object
         );
 
-        this.context = this.BuildAuthorizationContext(new[] { new Claim("groups", GROUP_ID) });
+        this.context = AuthorizationTestContext.BuildAuthorizationContext(new[] { new Claim("groups", GROUP_ID) });
     }
 
     [TestMethod]
@@ -68,7 +58,7 @@ public class LinkedToChatAuthorizationHandlerTest
     [TestMethod]
     public async Task UserWithoutGroupMembership_Should_NotSucceed()
     {
-        var context = this.BuildAuthorizationContext(new Claim[0]);
+        var context = AuthorizationTestContext.BuildAuthorizationContext(new Claim[0]);
 
         await this.handler!.HandleAsync(context);
 

--- a/webapi/Auth/Specializations/Models/SpecializationBody.cs
+++ b/webapi/Auth/Specializations/Models/SpecializationBody.cs
@@ -1,0 +1,6 @@
+﻿namespace CopilotChat.WebApi.Auth.Specializations.Models;
+
+public class SpecializationBody
+{
+    public string? SpecializationId { get; init; }
+}

--- a/webapi/Extensions/ServiceExtensions.cs
+++ b/webapi/Extensions/ServiceExtensions.cs
@@ -366,6 +366,7 @@ public static class CopilotChatServiceExtensions
         return services
             .AddScoped<IAuthorizationHandler, ChatParticipantAuthorizationHandler>()
             .AddScoped<IAuthorizationHandler, LinkedToChatAuthorizationHandler>()
+            .AddScoped<IAuthorizationHandler, AuthorizationHandler>()
             .AddAuthorizationCore(options =>
             {
                 options.DefaultPolicy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();


### PR DESCRIPTION
- feat: create AuthorizationHandler
- feat: create SpecializationBody

**Notes**
`SpecializationBody` is an attempt to fetch the smallest subset of `HttpContext.HttpRequest.Body`. I was debating if this was the best approach. I am open to any feedback.