### PR TITLE
Re-register completion services between requests

### DIFF
--- a/webapi/Extensions/SemanticKernelExtensions.cs
+++ b/webapi/Extensions/SemanticKernelExtensions.cs
@@ -128,7 +128,7 @@ internal static class SemanticKernelExtensions
 
     private static void InitializeKernelProvider(this WebApplicationBuilder builder)
     {
-        builder.Services.AddSingleton(sp =>
+        builder.Services.AddScoped(sp =>
         {
             var openAiRepo = sp.GetRequiredService<OpenAIDeploymentRepository>();
             var openAiService = new QOpenAIDeploymentService(

--- a/webapp/src/components/admin/specialization/SpecializationManager.tsx
+++ b/webapp/src/components/admin/specialization/SpecializationManager.tsx
@@ -462,7 +462,7 @@ export const SpecializationManager: React.FC = () => {
     const onDeploymentChange = (_event: SelectionEvents, data: OptionOnSelectData) => {
         const obj = JSON.parse(data.optionValue ?? '{}') as unknown as FormattedOpenAIDeployment;
         setDeploymentId(obj.id);
-        setCompletionDeploymentName(obj.deploymentName);
+        setCompletionDeploymentName(obj.completionName);
         const outputTokens = chatCompletionDeployments
             .find((d) => d.id === obj.id)
             ?.chatCompletionDeployments.find((a) => a.name === obj.deploymentName)?.outputTokens;


### PR DESCRIPTION
### Description

AddSingleton should be AddScoped for registering completion services otherwise new creations will never be registered without restarting the application.
