### PR TITLE
refactor: localize enum json serializer to CopilotChatMessageSortOption

### DIFF
--- a/webapi/Models/Request/CopilotChatMessageSortOption.cs
+++ b/webapi/Models/Request/CopilotChatMessageSortOption.cs
@@ -1,18 +1,12 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace CopilotChat.WebApi.Models.Request;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CopilotChatMessageSortOption
 {
-    [EnumMember(Value = "dateDesc")]
     DateDesc,
-
-    [EnumMember(Value = "dateAsc")]
     DateAsc,
-
-    [EnumMember(Value = "feedbackPos")]
     FeedbackPos,
-
-    [EnumMember(Value = "feedbackNeg")]
     FeedbackNeg,
 }

--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -94,7 +94,6 @@ public sealed class Program
             .AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-                options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
             });
         builder.Services.AddHealthChecks();
 

--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -4,7 +4,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using CopilotChat.WebApi.Extensions;
 using CopilotChat.WebApi.Hubs;


### PR DESCRIPTION
- refactor: localize enum serialization

**Notes**
This serialization strategy was added with the [user feedback admin page](https://github.com/Quartech/chat-copilot/pull/197#issue-2677497659) feature. This overwrote the enum serialization strategies of already existing APIs. One example:

`IChatMessage.authorRole` being returned as a string instead of an int caused messages to all be identified as not being written by the originating user:
![image](https://github.com/user-attachments/assets/ca4c6df9-9594-4961-ab83-91aa0969badc)
