### PR TITLE
added resources and limits

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -54,7 +54,12 @@ volumeMounts: []
 volumes: []
 configs: {}
 resources:
-  {}
+    requests:
+      cpu: 100m
+      memory: 450Mi
+    limits:
+      cpu: 350m
+      memory: 850Mi
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
The goal of this ticket is to set minimum available resources for a pod and set constraints on how much cpu and memory a pod can use. I added these values based on my interpretation of the cpu and memory usage of our pods roughly in the past 3 months. One thing to note is that our webapp pod uses less resources compared to webpi pods so I am not sure if we want to separate the resources for those pods. Feel free to change these values accordingly.



### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [Contribution Guidelines](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/chat-copilot/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
