### PR TITLE
refactor: update keepalive signal to be sent every 5 seconds

### DIFF
--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -51,9 +51,7 @@ public sealed class Program
             .AddChatCopilotAuthorization();
 
         // Add SignalR as the real time relay service
-        builder.Services.AddSignalR(hubOptions => {
-            hubOptions.KeepAliveInterval = TimeSpan.FromSeconds(5);
-        });
+        builder.Services.AddSignalR(hubOptions => hubOptions.KeepAliveInterval = TimeSpan.FromSeconds(5));
         builder.Services.AddSingleton<ISecretClientAccessor, SecretClientAccessor>();
 
         builder

--- a/webapi/Program.cs
+++ b/webapi/Program.cs
@@ -51,7 +51,9 @@ public sealed class Program
             .AddChatCopilotAuthorization();
 
         // Add SignalR as the real time relay service
-        builder.Services.AddSignalR();
+        builder.Services.AddSignalR(hubOptions => {
+            hubOptions.KeepAliveInterval = TimeSpan.FromSeconds(5);
+        });
         builder.Services.AddSingleton<ISecretClientAccessor, SecretClientAccessor>();
 
         builder

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -55,7 +55,7 @@ const setupSignalRConnectionToChatHub = () => {
 
     // Note: to keep the connection open the serverTimeout should be
     // larger than the KeepAlive value that is set on the server
-    hubConnection.keepAliveIntervalInMilliseconds = 20000;
+    hubConnection.keepAliveIntervalInMilliseconds = 5000;
     hubConnection.serverTimeoutInMilliseconds = 120000;
 
     return hubConnection;


### PR DESCRIPTION
- refactor: update keepalive signal to be sent every 5 seconds

**Notes**
The [keep alive signal](https://learn.microsoft.com/en-us/aspnet/signalr/overview/guide-to-the-api/handling-connection-lifetime-events#keepalive) is sent to the client and the server so both sides know the connection is still healthy. This signal also notifies other processes that the connection is still in use.

This is a simple test to understand where our limitations are on the dev site. There could be an environment config that prevents the signals from being sent at the desired interval or, there could be a client limitation as well where resources are stripped back for an idle page.