### PR TITLE
fix: use IndexName instead of IndexId for search service queries

### DIFF
--- a/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
+++ b/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
@@ -140,7 +140,9 @@ public class QAzureOpenAIChatExtension
         );
     }
 
-    public async Task<(string? indexName, string? ApiKey, string? Endpoint)> GetAISearchDeploymentConnectionDetails(string indexId)
+    public async Task<(string? indexName, string? ApiKey, string? Endpoint)> GetAISearchDeploymentConnectionDetails(
+        string indexId
+    )
     {
         var specializationIndex = await this._qSpecializationIndexService.GetIndexAsync(indexId);
         if (specializationIndex == null)
@@ -151,9 +153,10 @@ public class QAzureOpenAIChatExtension
             specializationIndex.AISearchDeploymentConnection
         );
         return (
-                specializationIndex.Name,
-                aiSearchDeploymentConnection?.APIKey,
-                aiSearchDeploymentConnection?.Endpoint?.ToString());
+            specializationIndex.Name,
+            aiSearchDeploymentConnection?.APIKey,
+            aiSearchDeploymentConnection?.Endpoint?.ToString()
+        );
     }
 
     /// <summary>

--- a/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
+++ b/webapi/Plugins/Chat/Ext/QAzureOpenAIChatExtension.cs
@@ -140,17 +140,20 @@ public class QAzureOpenAIChatExtension
         );
     }
 
-    public async Task<(string? ApiKey, string? Endpoint)> GetAISearchDeploymentConnectionDetails(string indexId)
+    public async Task<(string? indexName, string? ApiKey, string? Endpoint)> GetAISearchDeploymentConnectionDetails(string indexId)
     {
         var specializationIndex = await this._qSpecializationIndexService.GetIndexAsync(indexId);
         if (specializationIndex == null)
         {
-            return (null, null);
+            return (null, null, null);
         }
         var aiSearchDeploymentConnection = this.GetAISearchDeploymentConnection(
             specializationIndex.AISearchDeploymentConnection
         );
-        return (aiSearchDeploymentConnection?.APIKey, aiSearchDeploymentConnection?.Endpoint?.ToString());
+        return (
+                specializationIndex.Name,
+                aiSearchDeploymentConnection?.APIKey,
+                aiSearchDeploymentConnection?.Endpoint?.ToString());
     }
 
     /// <summary>

--- a/webapi/Services/QSearchService.cs
+++ b/webapi/Services/QSearchService.cs
@@ -56,7 +56,8 @@ public class QSearchService : IQSearchService
         {
             return null;
         }
-        var (indexName, apiKey, endpoint) = await this._qAzureOpenAIChatExtension.GetAISearchDeploymentConnectionDetails(indexId);
+        var (indexName, apiKey, endpoint) =
+            await this._qAzureOpenAIChatExtension.GetAISearchDeploymentConnectionDetails(indexId);
         if (indexName == null || apiKey == null || endpoint == null)
         {
             return null;

--- a/webapi/Services/QSearchService.cs
+++ b/webapi/Services/QSearchService.cs
@@ -56,15 +56,15 @@ public class QSearchService : IQSearchService
         {
             return null;
         }
-        var (apiKey, endpoint) = await this._qAzureOpenAIChatExtension.GetAISearchDeploymentConnectionDetails(indexId);
-        if (apiKey == null || endpoint == null)
+        var (indexName, apiKey, endpoint) = await this._qAzureOpenAIChatExtension.GetAISearchDeploymentConnectionDetails(indexId);
+        if (indexName == null || apiKey == null || endpoint == null)
         {
             return null;
         }
         using var httpRequestMessage = new HttpRequestMessage()
         {
             Method = HttpMethod.Post,
-            RequestUri = new Uri($"{endpoint}indexes/{indexId}/docs/search?api-version=2020-06-30"),
+            RequestUri = new Uri($"{endpoint}indexes/{indexName}/docs/search?api-version=2020-06-30"),
             Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json"),
         };
         httpRequestMessage.Headers.Add("api-Key", apiKey);


### PR DESCRIPTION
- fix: use IndexName instead of IndexId for search service queries

**Note**
Seems this is an artifact from an earlier change made to the system. `IndexName` was pulled into the `SpecializationIndex` table but, this change was not reflected in the `QSearchService` causing each query to return an empty result.