### PR TITLE
feat: send conversations on reconnect

### DIFF
--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -112,13 +112,10 @@ const registerCommonSignalConnectionEvents = (hubConnection: signalR.HubConnecti
     hubConnection.onreconnected((connectionId = '') => {
         if (hubConnection.state === signalR.HubConnectionState.Connected) {
             const message = 'Connection reestablished. Please refresh the page to ensure you have the latest data.';
-            // Temporary workaround to allow the app to function without forcing a refresh
 
-            // store.dispatch(
-            //     addReloadDialog({
-            //         text: message,
-            //     }),
-            // );
+            //TODO: remove this in favor of having the backend calculate the conversations that need to be updated via websocket
+            store.dispatch({ type: 'conversations/addConversationsToGroup', payload: store.getState().conversations.conversations });
+
             console.log(message + ` Connected with connectionId ${connectionId}`);
         }
     });

--- a/webapp/src/redux/features/message-relay/signalRHubConnection.ts
+++ b/webapp/src/redux/features/message-relay/signalRHubConnection.ts
@@ -114,7 +114,10 @@ const registerCommonSignalConnectionEvents = (hubConnection: signalR.HubConnecti
             const message = 'Connection reestablished. Please refresh the page to ensure you have the latest data.';
 
             //TODO: remove this in favor of having the backend calculate the conversations that need to be updated via websocket
-            store.dispatch({ type: 'conversations/addConversationsToGroup', payload: store.getState().conversations.conversations });
+            store.dispatch({
+                type: 'conversations/addConversationsToGroup',
+                payload: store.getState().conversations.conversations,
+            });
 
             console.log(message + ` Connected with connectionId ${connectionId}`);
         }

--- a/webapp/src/redux/features/message-relay/signalRMiddleware.ts
+++ b/webapp/src/redux/features/message-relay/signalRMiddleware.ts
@@ -48,6 +48,8 @@ export const signalRMiddleware: Middleware<any, RootState, Dispatch<SignalRActio
                     )
                     .catch((err) => store.dispatch(addAlert({ message: String(err), type: AlertType.Error })));
                 break;
+            //TODO: remove this in favor of having the backend calculate the conversations that need to be updated via websocket
+            case 'conversations/addConversationsToGroup':
             case 'conversations/setConversations':
                 Promise.all(
                     Object.keys(signalRAction.payload).map(async (id) => {


### PR DESCRIPTION
- feat: send conversations on reconnect

**Notes**
This is only meant to create a responsive and good user experience. There will be significant refactors coming which will see the backend calculating the conversations that need to emit events based on which user is currently online.

**Previously**
When a websocket closes, the user needs to refresh the web page in order to trigger the `conversations/setConversations` case in `signalRMiddleware`

**Proposal**
Reinitialize our websocket connection with the list of conversations that need to be updated when there are changes on the server with `signalR.ConnectionHub.onreconnected`.